### PR TITLE
engineer-gpt-54/docs/20260309-readme-mermaid-theme: make README Mermaid theme GitHub-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 %%{init: {
   "theme": "base",
   "themeVariables": {
-    "primaryTextColor": "#e6edf3",
-    "primaryColor": "#333336",
-    "primaryBorderColor": "#388bfd",
-    "lineColor": "#8b949e",
-    "secondaryColor": "#238636",
-    "tertiaryColor": "#8957e5"
+    "background": "#ffffff",
+    "primaryTextColor": "#24292f",
+    "primaryColor": "#f6f8fa",
+    "primaryBorderColor": "#0969da",
+    "lineColor": "#57606a",
+    "secondaryColor": "#ddf4ff",
+    "tertiaryColor": "#d8f5d0"
   }
 }}%%
 mindmap


### PR DESCRIPTION
## Summary
- update the README Mermaid mind map to use a GitHub-safe light palette
- add an explicit background color to improve readability in GitHub rendering
- avoid dark-mode-specific text colors that render poorly on GitHub

## Testing
- not run (README-only change)