### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is inspired by Keep a Changelog and semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Release preparation now installs `protoc` in the tag-triggered workflow so release builds match CI and bundled-wheel publish jobs.
+- Release notes and release checklist coverage now include the recurring Git and GitHub release commands used for recovery and normal publishes.
+
 ## [0.1.0] - 2026-03-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 repository = "https://github.com/micahcourey/mnemix"
 homepage = "https://github.com/micahcourey/mnemix"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Production Readiness Review (PRR)
 
-Mnemix `v0.2.0` is the first public release under the Mnemix name. This release carries forward the existing local-first memory engine, Python binding, bundled-wheel packaging, and advanced storage workflows, while updating the public package, CLI, crate, and documentation surfaces to the Mnemix brand. Deployment is handled through the existing GitHub Release to PyPI trusted-publishing workflow.
+Mnemix `v0.2.1` is the release-recovery follow-up to the initial `v0.2.0` rebrand publish attempt. This patch release keeps the public Mnemix surfaces introduced in `v0.2.0`, adds the missing `protoc` setup required by the tag-triggered release workflow, and carries forward the reusable release documentation needed for ongoing publishes.
 
 ---
 
@@ -9,20 +9,20 @@ Mnemix `v0.2.0` is the first public release under the Mnemix name. This release 
 | Field | Value |
 |-------|-------|
 | **Release Date** | 2026-03-10 |
-| **Release Window** | 21:54 UTC |
-| **Version** | `v0.2.0` |
-| **Release Type** | Minor |
-| **Release Epic** | `#28` |
+| **Release Window** | TBD |
+| **Version** | `v0.2.1` |
+| **Release Type** | Patch |
+| **Release Epic** | Release recovery |
 
 ## Release Scope
 
-This release publishes the first PyPI package under the `mnemix` name and aligns the Rust workspace, Python package, CLI, docs, and release process around the renamed project. It also formalizes the reusable release checklist for future releases.
+This release retries the first successful PyPI publish under the `mnemix` name after the failed `v0.2.0` attempt. It preserves the Mnemix rebrand and bundled-wheel packaging, while fixing the tag-driven release workflow and carrying the release documentation improvements merged after `v0.2.0`.
 
 | Ticket | Summary | Status |
 |--------|---------|--------|
 | `#26` | Rebrand Temporal Plane to Mnemix across public surfaces | Done |
-| `#24` | Bundle CLI in platform-specific PyPI wheels | Done |
-| `#28` | Prepare v0.2.0 release checklist and version bump | Done |
+| `#28` | Prepare the Mnemix release process and version alignment | Done |
+| `#30` | Restore `protoc` setup in the release workflow and ship release docs | Done |
 
 ## Stakeholders Approval & Notifications
 
@@ -30,11 +30,11 @@ This release publishes the first PyPI package under the `mnemix` name and aligns
 
 | Stakeholder | Role | Approval | Date |
 |-------------|------|----------|------|
-| Micah Courey | Maintainer / releaser | Approved | 2026-03-10 |
+| Micah Courey | Maintainer / releaser | Pending final release approval | 2026-03-10 |
 
 ## User Acceptance Test
 
-UAT for this release focused on packaging, installability, and release readiness rather than new product semantics. Validation covered Python package tests, source distribution build, metadata rendering, bundled-wheel verification, and local CLI packaging compatibility.
+UAT for this release remains focused on packaging, installability, and release readiness rather than new product semantics. Validation covers Python package tests, source distribution build, metadata rendering, bundled-wheel verification, and local CLI packaging compatibility against the post-merge release workflow and release docs.
 
 | Test Scenario | Tested By | Result |
 |---------------|-----------|--------|
@@ -45,22 +45,22 @@ UAT for this release focused on packaging, installability, and release readiness
 
 ## Release Known Issues
 
-This release has no known blocking issues.
+This release has no known code-level blockers, but PyPI trusted-publisher configuration still needs to be confirmed before publication.
 
 | Issue | Severity | Impact | Planned Fix |
 |-------|----------|--------|-------------|
-| GitHub Release notes were added after the release was created | Low | No impact on artifacts or publish behavior | Update the release body in place with `gh release edit` |
+| PyPI trusted-publisher configuration must match the `mnemix` project before publish | Medium | Publish can fail even if build artifacts are valid | Verify the PyPI publisher and rerun the release on `v0.2.1` |
 
 ## Release Test Results
 
-Release verification combined automated package validation with local release-preflight checks before the GitHub Release was published.
+Release verification combines automated package validation with local release-preflight checks before the `v0.2.1` GitHub Release is published.
 
 ### Security, Performance, & Accessibility
 
 | Test Type | Status | Notes |
 |-----------|--------|-------|
 | Security | Pass | PyPI publishing uses GitHub OIDC trusted publishing instead of a long-lived token |
-| Performance | N/A | This release focuses on naming, packaging, and release-process alignment |
+| Performance | N/A | This release focuses on release recovery and packaging alignment |
 | Section 508 / Accessibility | N/A | No UI surface is introduced by this release |
 | UX | Pass | Public installation and package naming now consistently use `mnemix` |
 
@@ -79,7 +79,7 @@ Release verification combined automated package validation with local release-pr
 - [x] Smoke tests passing
 - [x] Monitoring and alerts active
 - [x] Rollback plan documented
-- [x] GitHub Release published from tag `v0.2.0`
+- [ ] GitHub Release published from tag `v0.2.1`
 
 ## Production Post-Deployment Verification
 
@@ -87,12 +87,12 @@ Release verification combined automated package validation with local release-pr
 - [x] Key user flows validated
 - [x] Performance metrics within SLA
 - [x] No new errors in logs
-- [x] Stakeholders notified of successful deployment
+- [ ] Stakeholders notified of successful deployment
 - [ ] `pip install mnemix` confirmed against the live PyPI package page
 
 ## Release Statistics
 
-GitHub release: https://github.com/micahcourey/mnemix/releases/tag/v0.2.0
+GitHub release: pending `v0.2.1`
 
 | Metric | Value |
 |--------|-------|
@@ -103,10 +103,10 @@ GitHub release: https://github.com/micahcourey/mnemix/releases/tag/v0.2.0
 
 ## Notes & Miscellaneous Items
 
-The live release exists at `v0.2.0` and targets `main`. If the release notes need to be updated after publication, edit the release body in place with:
+When `v0.2.1` is published from `main`, update the release body in place with:
 
 ```bash
-gh release edit v0.2.0 --notes-file RELEASE_NOTES.md
+gh release edit v0.2.1 --notes-file RELEASE_NOTES.md
 ```
 
 Updating the release notes does not republish artifacts or rerun the PyPI workflow.

--- a/python/mnemix/_version.py
+++ b/python/mnemix/_version.py
@@ -1,3 +1,3 @@
 """Package version for the Mnemix Python distribution."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary
- bump the Rust workspace and Python package version to 0.2.1
- update the release changelog and RELEASE_NOTES.md for the recovery release
- keep the repo aligned with the merged release workflow fix on main

## Validation
- ./scripts/check-python-package.sh
- python test suite: 62 passed
- sdist build and twine metadata validation passed
- bundled wheel build and install verification passed
