### PR TITLE
fix: correct docs_site routing and Vercel output dir

### DIFF
--- a/docs_site/.vitepress/config.mts
+++ b/docs_site/.vitepress/config.mts
@@ -6,7 +6,6 @@ export default withMermaid(defineConfig({
     title: "Mnemix",
     description: "The Memory Engine for AI Agents",
     srcDir: './src',
-    outDir: './dist',
     cleanUrls: true,
     appearance: 'dark', // Default to dark mode
     head: [

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
             <Github size={20} />
             <span style={styles.linkText}>GitHub</span>
           </a>
-          <a href="#docs" className="btn btn-secondary" style={styles.btnSecondary}>
+          <a href="https://docs.mnemix.org/" target="_blank" rel="noreferrer" className="btn btn-secondary" style={styles.btnSecondary}>
             <BookOpen size={18} />
             Docs
           </a>


### PR DESCRIPTION
### Fixes
1. Removes the custom `outDir` from `docs_site/.vitepress/config.mts` so Vercel can find the generated VitePress files.
2. Updates the marketing site header to point the 'Docs' button to `https://docs.mnemix.org` instead of a local hash link.