### PR TITLE
fix: PyPI publication platform tag and suppress Node deprecation warnings

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             label: linux-x86_64
             cli_binary: target/release/mnemix
           - os: macos-latest

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,11 @@ if _bdist_wheel is not None:
         def get_tag(self) -> tuple[str, str, str]:
             python_tag, abi_tag, platform_tag = super().get_tag()
             if _has_bundled_cli():
+                if platform_tag == "linux_x86_64":
+                    # PyPI rejects generic 'linux_x86_64' tags.
+                    # Since we are bundling a binary built on Ubuntu 22.04+, 
+                    # we use a compatible manylinux tag.
+                    platform_tag = "manylinux_2_35_x86_64"
                 return ("py3", "none", platform_tag)
             return (python_tag, abi_tag, platform_tag)
 


### PR DESCRIPTION
This PR fixes the PyPI publication failure by correctly tagging Linux wheels with a manylinux tag and suppressing Node.js deprecation warnings in GitHub Actions workflows.

### Changes:
- **setup.py**: Overrides the Linux platform tag with `manylinux_2_35_x86_64` when a CLI binary is bundled.
- **Workflow Updates**: Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` across all workflows to opt into Node 24.
- **Runners**: Switched the Linux build runner to `ubuntu-22.04` for consistent GLIBC support.
- **Manual Triggers**: Enabled manual triggers (`workflow_dispatch`) for the Python publication workflow.