### PR TITLE
fix(lancedb): make linux batch collection types explicit

### DIFF
--- a/crates/mnemix-lancedb/src/backend.rs
+++ b/crates/mnemix-lancedb/src/backend.rs
@@ -256,7 +256,7 @@ impl LanceDbBackend {
                 .limit(1)
                 .execute()
                 .await?
-                .try_collect()
+                .try_collect::<Vec<RecordBatch>>()
                 .await?;
             Ok::<Vec<RecordBatch>, lancedb::Error>(batches)
         })?;
@@ -848,7 +848,7 @@ impl LanceDbBackend {
                 .select(Select::Columns(vec![PAYLOAD_COLUMN.to_owned()]))
                 .execute()
                 .await?
-                .try_collect()
+                .try_collect::<Vec<RecordBatch>>()
                 .await?;
 
             for batch in batches {
@@ -908,7 +908,11 @@ impl LanceDbBackend {
                 query = query.limit(limit);
             }
 
-            let batches: Vec<RecordBatch> = query.execute().await?.try_collect().await?;
+            let batches: Vec<RecordBatch> = query
+                .execute()
+                .await?
+                .try_collect::<Vec<RecordBatch>>()
+                .await?;
             Ok::<Vec<RecordBatch>, lancedb::Error>(batches)
         })?;
 
@@ -1600,7 +1604,7 @@ async fn table_contains_memory_id_async(
         .limit(1)
         .execute()
         .await?
-        .try_collect()
+        .try_collect::<Vec<RecordBatch>>()
         .await?;
 
     Ok(!batches.is_empty())


### PR DESCRIPTION
## Summary
- add explicit `try_collect::<Vec<RecordBatch>>()` target types at the remaining Linux-only ambiguous query sites in `mnemix-lancedb`
- keep the fix minimal and scoped to the exact Ubuntu compiler errors from the v0.2.4 publish run

## Verification
- cargo build --release -p mnemix-cli

## Context
- This follows PR #45. The previous fix removed the stream ambiguity, and this patch removes the remaining collection ambiguity on Linux.