### PR TITLE
fix(lancedb): make payload batch loop type explicit

### DIFF
--- a/crates/mnemix-lancedb/src/backend.rs
+++ b/crates/mnemix-lancedb/src/backend.rs
@@ -915,6 +915,7 @@ impl LanceDbBackend {
 
         let mut payloads = Vec::new();
         for batch in batches {
+            let batch: RecordBatch = batch;
             let Some(array): Option<&StringArray> =
                 batch.column(0).as_any().downcast_ref::<StringArray>()
             else {


### PR DESCRIPTION
## Summary
- add an explicit `RecordBatch` binding in the `query_payloads` loop
- keep the change scoped to the remaining Linux-only compiler error from the v0.2.6 publish run

## Verification
- cargo build --release -p mnemix-cli

## Context
- This follows PR #51. The previous fix pinned the Rust toolchain and made the query execution stream types explicit.
- The publish logs still showed one remaining Linux-only inference failure at the payload decode loop.