### PR TITLE
fix(release): harden linux release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
   bundled-wheel-linux:
     name: Bundled wheel smoke test (linux-x86_64)
     runs-on: ubuntu-22.04
+    env:
+      CARGO_TARGET_DIR: /tmp/mnemix-ci-linux-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,14 +70,11 @@ jobs:
           version: "27.3"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
-
       - name: Build CLI release binary
         run: cargo build --release -p mnemix-cli
 
       - name: Build and verify bundled wheel
         env:
           PYTHON_BIN: python
-          TP_CLI_BINARY: target/release/mnemix
+          TP_CLI_BINARY: /tmp/mnemix-ci-linux-release/release/mnemix
         run: ./scripts/check-python-bundled-wheel.sh

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -68,13 +68,16 @@ jobs:
         include:
           - os: ubuntu-22.04
             label: linux-x86_64
-            cli_binary: target/release/mnemix
+            cli_binary: /tmp/mnemix-publish-linux-release/release/mnemix
+            cargo_target_dir: /tmp/mnemix-publish-linux-release
           - os: macos-latest
             label: macos-arm64
             cli_binary: target/release/mnemix
+            cargo_target_dir: target
           - os: windows-latest
             label: windows-x86_64
             cli_binary: target/release/mnemix.exe
+            cargo_target_dir: target
 
     steps:
       - uses: actions/checkout@v4
@@ -96,14 +99,18 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache cargo artifacts
+        if: matrix.label != 'linux-x86_64'
         uses: Swatinem/rust-cache@v2
 
       - name: Build CLI release binary
+        env:
+          CARGO_TARGET_DIR: ${{ matrix.cargo_target_dir }}
         run: cargo build --release -p mnemix-cli
 
       - name: Build and verify bundled wheel
         shell: bash
         env:
+          CARGO_TARGET_DIR: ${{ matrix.cargo_target_dir }}
           PYTHON_BIN: python
           TP_CLI_BINARY: ${{ matrix.cli_binary }}
         run: ./scripts/check-python-bundled-wheel.sh

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -46,6 +46,7 @@ main branch
 |-------|-------------------|----------|-----------|
 | Version alignment | Compare `Cargo.toml` and `python/mnemix/_version.py` | Same version string | Every release |
 | Local preflight | `./scripts/check-python-package.sh` | Exit code `0` | Every release |
+| Local Linux release build | `./scripts/check-linux-release-build.sh` | Exit code `0` | Before tagging |
 | Release workflow | GitHub Actions `Publish Python` | All jobs succeed | Every release |
 | Package availability | `python3 -m pip index versions mnemix` | New version listed | Every release |
 
@@ -61,7 +62,7 @@ main branch
 
 | Alert | Severity | Threshold | Action |
 |-------|----------|-----------|--------|
-| Preflight failure | P1 | Any non-zero exit from `./scripts/check-python-package.sh` | Stop release and fix before tagging |
+| Preflight failure | P1 | Any non-zero exit from `./scripts/check-python-package.sh` or `./scripts/check-linux-release-build.sh` | Stop release and fix before tagging |
 | Publish workflow failure | P1 | Any failed job in `Publish Python` after a release is published | Inspect logs and rerun only after root cause is fixed |
 | Version mismatch | P1 | GitHub tag, Cargo version, and Python version do not match | Correct versions and cut a new release |
 | Missing PyPI package update | P1 | New version absent from PyPI after successful workflow | Verify trusted publishing and package artifacts |
@@ -127,17 +128,20 @@ main branch
 2. Bump the version in `python/mnemix/_version.py` and `Cargo.toml`.
 3. Update any release-facing docs that depend on the current release procedure or version.
 4. Run `./scripts/check-python-package.sh`.
+5. Run `./scripts/check-linux-release-build.sh`.
   Shortcut:
   `./scripts/release.sh X.Y.Z` automates the release-prep PR path when the only required release edits are the version bumps in `Cargo.toml` and `python/mnemix/_version.py`.
-5. Merge the release-prep PR to `main`.
+6. Merge the release-prep PR to `main`.
   Commands:
   `git checkout main`
   `git pull --ff-only origin main`
-6. Create and publish a GitHub Release tagged `vX.Y.Z` from the verified `main` commit.
+7. Create and publish a GitHub Release tagged `vX.Y.Z` from the verified `main` commit.
   Commands:
   `./scripts/publish-release.sh X.Y.Z`
-7. Wait for `.github/workflows/publish-python.yml` to complete successfully.
-8. Verify the new version on PyPI and in a clean install.
+  Note:
+  `./scripts/publish-release.sh X.Y.Z` now runs `./scripts/check-linux-release-build.sh` before creating the tag.
+8. Wait for `.github/workflows/publish-python.yml` to complete successfully.
+9. Verify the new version on PyPI and in a clean install.
 
 ### Rollback
 
@@ -150,7 +154,7 @@ main branch
 
 1. Limit emergency releases to packaging or publish-blocking fixes.
 2. Keep the diff minimal and directly tied to the failed release.
-3. Re-run `./scripts/check-python-package.sh` before publishing the emergency fix.
+3. Re-run `./scripts/check-python-package.sh` and `./scripts/check-linux-release-build.sh` before publishing the emergency fix.
 4. Publish a new GitHub Release with the next version.
   Commands:
   `git checkout main`

--- a/scripts/check-linux-release-build.sh
+++ b/scripts/check-linux-release-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "required command not found: $command_name" >&2
+    exit 1
+  fi
+}
+
+require_command docker
+
+docker run --rm \
+  -v "$repo_root:/work:ro" \
+  ubuntu:22.04 \
+  bash -lc '
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      clang \
+      cmake \
+      curl \
+      libssl-dev \
+      pkg-config \
+      protobuf-compiler
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.94.0 --profile minimal
+    . "$HOME/.cargo/env"
+    export CARGO_HOME=/tmp/cargo-home
+    export CARGO_TARGET_DIR=/tmp/mnemix-linux-release-target
+    cargo build --manifest-path /work/Cargo.toml --release -p mnemix-cli
+  '

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -84,6 +84,7 @@ PY
 require_command git
 require_command gh
 require_command python3
+require_command docker
 
 current_branch="$(git branch --show-current)"
 if [[ "$current_branch" != "main" ]]; then
@@ -124,6 +125,7 @@ if [[ "$workspace_version" != "$version" || "$python_version" != "$version" ]]; 
   exit 1
 fi
 
+run ./scripts/check-linux-release-build.sh
 run git tag -a "$tag" -m "$tag"
 run git push origin "$tag"
 run gh release create "$tag" --title "$tag" --generate-notes


### PR DESCRIPTION
## Summary
- make the Linux bundled-wheel CI and publish jobs build from a clean target dir instead of restoring cached Rust artifacts
- add a Docker-based Ubuntu 22.04 release-build preflight and run it from \
- document the Linux preflight in the release checklist

## Verification
- bash -n scripts/check-linux-release-build.sh scripts/publish-release.sh scripts/release.sh scripts/check-python-package.sh scripts/check-python-bundled-wheel.sh
- git diff --check

## Why
The Linux publish failures were still slipping past PR validation. This change makes the Linux smoke test closer to the real publish path and adds a local pre-tag Linux gate.