### PR TITLE
chore(release): prepare v0.2.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.7"
+version = "0.2.8"
 license = "MIT"
 repository = "https://github.com/micahcourey/mnemix"
 homepage = "https://github.com/micahcourey/mnemix"

--- a/python/mnemix/_version.py
+++ b/python/mnemix/_version.py
@@ -1,3 +1,3 @@
 """Package version for the Mnemix Python distribution."""
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"


### PR DESCRIPTION
## Summary
- bump the workspace version to 0.2.8
- bump the Python package version to 0.2.8
- run the Python package release preflight before publishing

## Verification
- ./scripts/check-python-package.sh

## Follow-up
- After this PR merges, run ./scripts/publish-release.sh 0.2.8 from a clean main checkout.