### PR TITLE
fix(release): build docker preflight from writable copy

### DIFF
--- a/scripts/check-linux-release-build.sh
+++ b/scripts/check-linux-release-build.sh
@@ -31,7 +31,8 @@ docker run --rm \
       protobuf-compiler
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.94.0 --profile minimal
     . "$HOME/.cargo/env"
+    cp -a /work /tmp/mnemix-linux-release-src
     export CARGO_HOME=/tmp/cargo-home
     export CARGO_TARGET_DIR=/tmp/mnemix-linux-release-target
-    cargo build --manifest-path /work/Cargo.toml --release -p mnemix-cli
+    cargo build --manifest-path /tmp/mnemix-linux-release-src/Cargo.toml --release -p mnemix-cli
   '


### PR DESCRIPTION
## Summary
- copy the repository into a writable temp directory inside the Ubuntu Docker preflight container
- keep the host checkout mounted read-only while allowing cargo to update lock/build state during the Linux release check

## Verification
- bash -n scripts/check-linux-release-build.sh
- git diff --check

## Why
The new Linux preflight failed before publish because cargo could not write Cargo.lock through the read-only bind mount.