### PR TITLE
fix(release): align docker preflight with linux publish

### DIFF
--- a/scripts/check-linux-release-build.sh
+++ b/scripts/check-linux-release-build.sh
@@ -14,6 +14,7 @@ require_command() {
 require_command docker
 
 docker run --rm \
+  --platform linux/amd64 \
   -v "$repo_root:/work:ro" \
   ubuntu:22.04 \
   bash -lc '
@@ -26,6 +27,7 @@ docker run --rm \
       clang \
       cmake \
       curl \
+      libprotobuf-dev \
       libssl-dev \
       pkg-config \
       protobuf-compiler
@@ -34,5 +36,6 @@ docker run --rm \
     cp -a /work /tmp/mnemix-linux-release-src
     export CARGO_HOME=/tmp/cargo-home
     export CARGO_TARGET_DIR=/tmp/mnemix-linux-release-target
+    export PROTOC_INCLUDE=/usr/include
     cargo build --manifest-path /tmp/mnemix-linux-release-src/Cargo.toml --release -p mnemix-cli
   '


### PR DESCRIPTION
## Summary
- run the Docker Linux preflight as linux/amd64 to match the publish target
- install libprotobuf-dev so protoc can resolve google/protobuf includes
- export PROTOC_INCLUDE=/usr/include during the preflight build

## Verification
- bash -n scripts/check-linux-release-build.sh
- git diff --check

## Why
The first Docker preflight fix was merged, but local publish still failed because the container was running arm64 and lacked the protobuf include files used by lance-encoding's build script.