### PR TITLE
fix(python): add pipx console entry points

### DIFF
--- a/python/mnemix/_runner.py
+++ b/python/mnemix/_runner.py
@@ -31,31 +31,32 @@ from .errors import (
 # installations.
 _ENV_BINARY = "MNEMIX_BINARY"
 _BINARY_NAME = "mnemix"
+_BINARY_ALIAS_NAME = "mx"
 
 
-def _platform_binary_name() -> str:
+def _platform_binary_name(binary_name: str = _BINARY_NAME) -> str:
     if sys.platform == "win32":
-        return f"{_BINARY_NAME}.exe"
-    return _BINARY_NAME
+        return f"{binary_name}.exe"
+    return binary_name
 
 
-def _find_bundled_binary() -> str | None:
+def _find_bundled_binary(binary_name: str = _BINARY_NAME) -> str | None:
     """Return the packaged CLI binary path when the wheel bundles one."""
     candidate = resources.files("mnemix").joinpath(
-        "_bin", _platform_binary_name()
+        "_bin", _platform_binary_name(binary_name)
     )
     if candidate.is_file():
         return os.fspath(candidate)
     return None
 
 
-def _find_binary() -> str:
-    """Return the path to the ``mnemix`` binary.
+def _find_binary(binary_name: str = _BINARY_NAME) -> str:
+    """Return the path to a CLI binary.
 
     Resolution order:
     1. ``MNEMIX_BINARY`` environment variable.
     2. Bundled wheel binary, if present.
-    3. ``mnemix`` on ``PATH`` via :func:`shutil.which`.
+    3. The requested binary on ``PATH`` via :func:`shutil.which`.
 
     Raises:
         MnemixBinaryNotFoundError: if the binary cannot be found.
@@ -64,20 +65,27 @@ def _find_binary() -> str:
     if from_env:
         return from_env
 
-    bundled = _find_bundled_binary()
+    bundled = _find_bundled_binary(binary_name)
     if bundled:
         return bundled
 
-    found = shutil.which(_platform_binary_name())
+    found = shutil.which(_platform_binary_name(binary_name))
     if found:
         return found
 
     raise MnemixBinaryNotFoundError(
-        f"Could not find the '{_platform_binary_name()}' binary. "
+        f"Could not find the '{_platform_binary_name(binary_name)}' binary. "
         "Install a Mnemix wheel that bundles the CLI, install the "
         f"Mnemix CLI separately, or set the {_ENV_BINARY} environment "
         "variable to the absolute path of the binary."
     )
+
+
+def _run_cli_entrypoint(binary_name: str) -> int:
+    """Run the requested CLI binary for console-script entry points."""
+    binary = _find_binary(binary_name)
+    completed = subprocess.run([binary, *sys.argv[1:]], check=False)
+    return completed.returncode
 
 
 def run(
@@ -146,3 +154,13 @@ def run(
 
     # Flat outputs (e.g. init status) have no nested "data" key.
     return envelope  # type: ignore[return-value]
+
+
+def main() -> int:
+    """Entry point for the packaged ``mnemix`` console script."""
+    return _run_cli_entrypoint(_BINARY_NAME)
+
+
+def main_alias() -> int:
+    """Entry point for the packaged ``mx`` console script."""
+    return _run_cli_entrypoint(_BINARY_ALIAS_NAME)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,6 +25,10 @@ Repository = "https://github.com/micahcourey/mnemix"
 Issues = "https://github.com/micahcourey/mnemix/issues"
 Changelog = "https://github.com/micahcourey/mnemix/blob/main/CHANGELOG.md"
 
+[project.scripts]
+mnemix = "mnemix._runner:main"
+mx = "mnemix._runner:main_alias"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",

--- a/python/tests/test_runner.py
+++ b/python/tests/test_runner.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mnemix._runner import run
+from mnemix._runner import main, main_alias, run
 from mnemix.errors import (
     MnemixBinaryNotFoundError,
     MnemixCommandError,
@@ -67,6 +67,38 @@ class TestFindBinary:
             from mnemix._runner import _platform_binary_name
 
             assert _platform_binary_name() == "mnemix.exe"
+            assert _platform_binary_name("mx") == "mx.exe"
+
+    def test_binary_alias_uses_bundled_alias_when_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MNEMIX_BINARY", raising=False)
+        assert_path = "/wheel/mx"
+        with patch("mnemix._runner._find_bundled_binary", return_value=assert_path), \
+             patch("shutil.which", return_value=None):
+            from mnemix._runner import _find_binary
+
+            assert _find_binary("mx") == assert_path
+
+
+class TestConsoleScripts:
+    def test_main_entrypoint_runs_mnemix_binary(self) -> None:
+        with patch("mnemix._runner._find_binary", return_value="/wheel/mnemix") as mock_find, \
+             patch("subprocess.run", return_value=_make_result("", returncode=0)) as mock_run, \
+             patch("sys.argv", ["mnemix", "--help"]):
+            exit_code = main()
+
+        assert exit_code == 0
+        mock_find.assert_called_once_with("mnemix")
+        mock_run.assert_called_once_with(["/wheel/mnemix", "--help"], check=False)
+
+    def test_main_alias_runs_mx_binary(self) -> None:
+        with patch("mnemix._runner._find_binary", return_value="/wheel/mx") as mock_find, \
+             patch("subprocess.run", return_value=_make_result("", returncode=0)) as mock_run, \
+             patch("sys.argv", ["mx", "--help"]):
+            exit_code = main_alias()
+
+        assert exit_code == 0
+        mock_find.assert_called_once_with("mx")
+        mock_run.assert_called_once_with(["/wheel/mx", "--help"], check=False)
 
 
 class TestRunDecoding:


### PR DESCRIPTION
## Summary
- add console-script entry points for mnemix and mx so pipx recognizes the package as an app
- route those entry points through thin Python launchers that invoke the bundled CLI binary
- add runner tests for the new console-script behavior

## Verification
- /Users/micah/Projects/mnemix/python/.venv/bin/python -m pytest python/tests/test_runner.py -q
- /Users/micah/Projects/mnemix/python/.venv/bin/python -m build --wheel
- verified wheel metadata contains console_scripts for mnemix and mx
- built a bundled wheel with scripts/build-python-wheel-with-cli.sh
- pipx install of the bundled wheel into a temporary PIPX_HOME exposed both mnemix and mx
- /tmp isolated pipx install: mnemix --help
- /tmp isolated pipx install: mx --help