### PR TITLE
Document pipx install flow and host adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ On supported platforms, the PyPI wheel bundles the `mnemix` CLI binary:
 pip install mnemix
 ```
 
+If you want the CLI as a standalone tool, prefer `pipx`:
+
+```bash
+pipx install mnemix
+```
+
 If no bundled wheel is available for your platform, install the CLI from source:
 
 ```bash
@@ -166,10 +172,16 @@ mnemix --store .mnemix restore --checkpoint before-refactor
 
 ## Python client
 
-Install from PyPI:
+For library use, install from PyPI:
 
 ```bash
 pip install mnemix
+```
+
+For CLI-first use, install with `pipx`:
+
+```bash
+pipx install mnemix
 ```
 
 > On supported platforms, the wheel includes the `mnemix` CLI binary and works without any extra setup. If you are on an unsupported platform or using a source install, install the CLI separately and ensure it is on `PATH`, or set `MNEMIX_BINARY=/path/to/mnemix`.
@@ -206,6 +218,26 @@ for m in results:
 stats = client.stats()
 print(f"Total memories: {stats.total_memories}")
 ```
+
+---
+
+## Host adapters
+
+Mnemix keeps the base Python client generic and puts workflow policy in
+host-specific adapters under [`adapters/`](/Users/micah/Projects/mnemix/adapters).
+
+Available adapters:
+
+- `CodingAgentAdapter` for implementation tasks, decisions, procedures, and pitfalls
+- `ChatAssistantAdapter` for user preferences and durable chat context
+- `CiBotAdapter` for automated runs, checkpoints, failures, and fixes
+- `ReviewToolAdapter` for review rules, conventions, and recurring issues
+
+See:
+
+- [adapters/README.md](/Users/micah/Projects/mnemix/adapters/README.md)
+- [docs_site/src/guide/host-adapters.md](/Users/micah/Projects/mnemix/docs_site/src/guide/host-adapters.md)
+- [examples/agent-memory-layer/README.md](/Users/micah/Projects/mnemix/examples/agent-memory-layer/README.md)
 
 ---
 

--- a/docs_site/src/guide/host-adapters.md
+++ b/docs_site/src/guide/host-adapters.md
@@ -84,6 +84,28 @@ The coding adapter also exposes:
 - version inspection and restore
 - optimize, export, and staged import helpers
 
+### CodingAgentAdapter API
+
+| Method | Purpose |
+|---|---|
+| `start_task(...)` | Assemble task-start context with recall, pins, and recent history |
+| `search_memory(...)` | Run targeted search during implementation work |
+| `load_memory(...)` | Inspect one memory in full detail |
+| `list_pins(...)` | View pinned memory for the current repo or scope |
+| `review_recent_memory(...)` | Inspect recent memory activity |
+| `checkpoint_before_risky_change(...)` | Create a safety checkpoint before risky work |
+| `list_versions(...)` | Inspect store version history |
+| `restore_checkpoint(...)` | Restore to a named checkpoint |
+| `restore_version(...)` | Restore to a specific version |
+| `optimize_store(...)` | Run compaction and optional pruning |
+| `export_snapshot(...)` | Export the current store |
+| `stage_import(...)` | Stage an imported store into the current store |
+| `store_decision(...)` | Persist a durable design decision |
+| `store_procedure(...)` | Persist a reusable coding procedure |
+| `store_summary(...)` | Persist a session/task summary |
+| `store_fact(...)` | Persist a stable project fact |
+| `store_pitfall(...)` | Persist a recurring implementation warning |
+
 ## Chat assistant workflow
 
 Chat assistants should usually store much less than coding agents. The main
@@ -109,6 +131,14 @@ Use chat writeback for:
 - stable factual context that should persist across sessions
 
 Avoid storing transient turn-by-turn summaries.
+
+### ChatAssistantAdapter API
+
+| Method | Purpose |
+|---|---|
+| `prepare_reply(...)` | Recall prompt-ready user and conversation context |
+| `store_preference(...)` | Persist a durable user preference |
+| `store_fact(...)` | Persist a stable user- or task-relevant fact |
 
 ## CI bot workflow
 
@@ -137,6 +167,14 @@ Use CI writeback for:
 - runbook-quality fixes
 - operational warnings that should influence later runs
 
+### CiBotAdapter API
+
+| Method | Purpose |
+|---|---|
+| `prepare_run(...)` | Recall CI context and optionally create a pre-run checkpoint |
+| `record_failure(...)` | Persist a recurring CI failure mode |
+| `record_fix(...)` | Persist a reusable remediation procedure |
+
 ## Review tool workflow
 
 Review tools need reusable review knowledge rather than generic task history.
@@ -160,6 +198,14 @@ Use review writeback for:
 - reusable review rules
 - recurring quality issues
 - project-specific review conventions
+
+### ReviewToolAdapter API
+
+| Method | Purpose |
+|---|---|
+| `prepare_review(...)` | Recall project conventions and review context |
+| `record_review_rule(...)` | Persist a reusable review rule or policy |
+| `record_recurring_issue(...)` | Persist a recurring review finding or quality issue |
 
 ## Design rule
 

--- a/docs_site/src/guide/python.md
+++ b/docs_site/src/guide/python.md
@@ -17,6 +17,12 @@ Install from PyPI:
 pip install mnemix
 ```
 
+If you mainly want the CLI as a standalone tool, install it with `pipx`:
+
+```bash
+pipx install mnemix
+```
+
 On supported platforms, the wheel bundles the `mnemix` CLI binary. If your platform does not have a bundled binary, install the CLI separately or point `MNEMIX_BINARY` at an existing binary.
 
 ## Quick start
@@ -87,6 +93,11 @@ The client resolves the CLI binary in this order:
 3. `mnemix` on `PATH`
 
 This makes it easy to use published wheels, local development builds, or custom binaries in tests and integrations.
+
+## pip vs pipx
+
+- Use `pip install mnemix` when you want the Python package as a library dependency.
+- Use `pipx install mnemix` when you mainly want the `mnemix` CLI available on your shell.
 
 ## Design notes
 

--- a/examples/chat-assistant/README.md
+++ b/examples/chat-assistant/README.md
@@ -1,0 +1,47 @@
+# Chat Assistant Example
+
+This example shows how to use [`ChatAssistantAdapter`](/Users/micah/Projects/mnemix/adapters/chat_assistant_adapter.py)
+for a conversational assistant that should remember durable user preferences
+without storing noisy turn-by-turn summaries.
+
+## Typical flow
+
+1. initialize the store
+2. prepare reply context from existing memory
+3. answer the user
+4. store only durable user preferences or stable facts
+
+## Example
+
+```python
+from pathlib import Path
+from adapters import ChatAssistantAdapter
+
+adapter = ChatAssistantAdapter(store=Path(".mnemix"))
+adapter.ensure_store()
+
+context = adapter.prepare_reply(
+    scope="user:demo",
+    user_message="Please keep answers concise and avoid long lists.",
+)
+print(context.prompt_preamble)
+
+adapter.store_preference(
+    memory_id="memory:user-pref-concise",
+    scope="user:demo",
+    title="Prefer concise answers",
+    summary="The user prefers direct answers with minimal extra detail.",
+    detail="Default to short replies unless the user explicitly asks for more depth.",
+)
+```
+
+## Good writeback
+
+- user preferences
+- stable user facts that will matter again
+
+## Avoid
+
+- turn-by-turn summaries
+- temporary conversational details
+- generic chat logs

--- a/examples/ci-bot/README.md
+++ b/examples/ci-bot/README.md
@@ -1,0 +1,47 @@
+# CI Bot Example
+
+This example shows how to use [`CiBotAdapter`](/Users/micah/Projects/mnemix/adapters/ci_bot_adapter.py)
+for automated CI workflows that need memory about failures, fixes, and safe
+pre-run checkpoints.
+
+## Typical flow
+
+1. initialize the store
+2. prepare run context for the pipeline
+3. create a checkpoint before risky automation
+4. run the pipeline
+5. store recurring failures or reusable fixes
+
+## Example
+
+```python
+from pathlib import Path
+from adapters import CiBotAdapter
+
+adapter = CiBotAdapter(store=Path(".mnemix"))
+adapter.ensure_store()
+
+run = adapter.prepare_run(
+    scope="repo:mnemix",
+    run_id="42",
+    pipeline="publish-python",
+)
+print(run.bundle.prompt_preamble)
+print(run.checkpoint)
+
+adapter.record_failure(
+    memory_id="memory:ci-failure-qemu",
+    scope="repo:mnemix",
+    title="QEMU-based linux preflight fails on arm macs",
+    summary="The emulated preflight path is unreliable on local arm macOS hosts.",
+    detail="Prefer skipping that local preflight path when the release workflow already validates the linux build elsewhere.",
+)
+
+adapter.record_fix(
+    memory_id="memory:ci-fix-preflight",
+    scope="repo:mnemix",
+    title="Use docker writable copy for linux preflight",
+    summary="Build the preflight image from a writable copy to avoid read-only mount issues.",
+    detail="The writable-copy workaround avoids permission failures during local release verification.",
+)
+```

--- a/examples/python-basic/example.py
+++ b/examples/python-basic/example.py
@@ -1,7 +1,7 @@
 """Basic Mnemix Python binding example.
 
 Run with:
-    tp binary on PATH (cargo build --release, then add target/release to PATH)
+    mnemix binary on PATH (cargo build --release, then add target/release to PATH)
     pip install -e ../../python
     python example.py
 """

--- a/examples/review-tool/README.md
+++ b/examples/review-tool/README.md
@@ -1,0 +1,45 @@
+# Review Tool Example
+
+This example shows how to use [`ReviewToolAdapter`](/Users/micah/Projects/mnemix/adapters/review_tool_adapter.py)
+for code review workflows that need reusable review rules and recurring issue
+tracking.
+
+## Typical flow
+
+1. initialize the store
+2. prepare review context for the current topic
+3. perform the review
+4. store reusable rules or recurring findings
+
+## Example
+
+```python
+from pathlib import Path
+from adapters import ReviewToolAdapter
+
+adapter = ReviewToolAdapter(store=Path(".mnemix"))
+adapter.ensure_store()
+
+context = adapter.prepare_review(
+    scope="repo:mnemix",
+    review_topic="adapter verification expectations",
+)
+print(context.prompt_preamble)
+
+adapter.record_review_rule(
+    memory_id="memory:review-rule-verification",
+    scope="repo:mnemix",
+    title="Call out missing verification",
+    summary="Reviews should explicitly note when tests or checks were not run.",
+    detail="If a change was not fully verified, the review result should state the gap clearly so the next step is obvious.",
+    pin_reason="Project-wide review rule",
+)
+
+adapter.record_recurring_issue(
+    memory_id="memory:review-issue-metadata",
+    scope="repo:mnemix",
+    title="Examples drift from implementation",
+    summary="Example and docs changes often lag the actual adapter surface.",
+    detail="Review changes to adapters with corresponding docs and examples so public guidance stays aligned.",
+)
+```

--- a/python/README.md
+++ b/python/README.md
@@ -23,6 +23,13 @@ Install the Python wrapper from PyPI:
 pip install mnemix
 ```
 
+If you primarily want the `mnemix` CLI as an isolated command-line tool,
+prefer `pipx`:
+
+```bash
+pipx install mnemix
+```
+
 On supported platforms, this wheel includes the Rust `mnemix` CLI
 binary and should work without any additional setup.
 
@@ -124,3 +131,7 @@ exposes `__version__` correctly.
 The current binding uses the CLI `--json` surface as the execution boundary.
 Direct FFI via PyO3 is deferred until a dedicated stable Rust application API
 exists and there is a concrete need that the CLI boundary cannot satisfy.
+
+If you are using Mnemix as a Python library inside an application, use
+`pip install mnemix`. If you are installing it mainly for the `mnemix` command,
+`pipx install mnemix` is usually the better fit.


### PR DESCRIPTION
## Summary
- add `pipx` guidance to the main README, Python README, and docs-site Python guide
- add a host-adapters section to the top-level README and expand the docs-site host adapter guide with API tables
- add per-adapter examples for chat assistant, CI bot, and review tool workflows

## Verification
- documentation-only review of updated install and adapter references
- existing repo state left `.dex` sync-state changes uncommitted and out of this PR