### PR TITLE
Expand coding adapter policy surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ No cloud, no daemon, no configuration sprawl. Just a local store on your filesys
 
 ---
 
+## Ecosystem
+
+Mnemix is also part of a broader tooling ecosystem. For config-driven,
+multi-platform generation of AI coding resources, see
+[mnemix-context](https://github.com/micahcourey/mnemix-context), a companion
+project for generating reusable agent instructions, prompts, skills, and other
+coding-assistant resources.
+
+---
+
 ## How it works
 
 An agent calls `remember` to persist an observation, decision, or fact. Later sessions call `recall` or `search` to retrieve the most relevant context. The full version history of the store is preserved — you can checkpoint before risky operations, list what changed, and restore to any prior state.
@@ -238,6 +248,10 @@ See:
 - [adapters/README.md](/Users/micah/Projects/mnemix/adapters/README.md)
 - [docs_site/src/guide/host-adapters.md](/Users/micah/Projects/mnemix/docs_site/src/guide/host-adapters.md)
 - [examples/agent-memory-layer/README.md](/Users/micah/Projects/mnemix/examples/agent-memory-layer/README.md)
+
+For a more comprehensive coding-agent adapter and reusable agent memory policy
+template, see the `mnemix-context` templates here:
+[mnemix-context/templates/universal/mnemix](https://github.com/micahcourey/mnemix-context/tree/main/templates/universal/mnemix)
 
 ---
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -19,9 +19,12 @@ storage internals.
 `CodingAgentAdapter` is the richest adapter because coding agents are currently
 the primary host workflow. It now covers:
 
+- scope helpers for repo, workspace, session, and task namespaces
 - task-start recall modes (`quick`, `normal`, `deep`)
 - pinned-memory and recent-history context assembly
 - targeted search and memory inspection
+- typed outcome classification with an explicit skip path
+- `store_outcome(...)` for policy-driven writeback
 - decisions, procedures, summaries, facts, and pitfalls
 - pre-change checkpoints
 - version inspection and restore

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -2,12 +2,22 @@
 
 from .chat_assistant_adapter import ChatAssistantAdapter
 from .ci_bot_adapter import CiBotAdapter
-from .coding_agent_adapter import CodingAgentAdapter
+from .coding_agent_adapter import (
+    CodingAgentAdapter,
+    CodingOutcome,
+    CodingTaskContext,
+    OutcomeClassification,
+    StoredOutcomeResult,
+)
 from .review_tool_adapter import ReviewToolAdapter
 
 __all__ = [
     "ChatAssistantAdapter",
     "CiBotAdapter",
     "CodingAgentAdapter",
+    "CodingOutcome",
+    "CodingTaskContext",
+    "OutcomeClassification",
     "ReviewToolAdapter",
+    "StoredOutcomeResult",
 ]

--- a/adapters/_adapter_base.py
+++ b/adapters/_adapter_base.py
@@ -105,9 +105,14 @@ class BaseAdapter:
         summary: str,
         detail: str,
         importance: int,
+        confidence: int = 100,
         tags: list[str] | None = None,
+        entities: list[str] | None = None,
         pin_reason: str | None = None,
         source_tool: str | None = None,
+        source_session_id: str | None = None,
+        source_ref: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> MemoryDetail:
         from mnemix.models import RememberRequest
 
@@ -120,8 +125,13 @@ class BaseAdapter:
                 summary=summary,
                 detail=detail,
                 importance=importance,
+                confidence=confidence,
                 tags=tags or [],
+                entities=entities or [],
                 pin_reason=pin_reason,
                 source_tool=source_tool,
+                source_session_id=source_session_id,
+                source_ref=source_ref,
+                metadata=metadata or {},
             )
         )

--- a/adapters/coding_agent_adapter.py
+++ b/adapters/coding_agent_adapter.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 from typing import Literal
 
 from mnemix.models import OptimizeRequest, RestoreRequest
@@ -10,6 +11,8 @@ from mnemix.models import OptimizeRequest, RestoreRequest
 from ._adapter_base import BaseAdapter, ContextBundle
 
 TaskMode = Literal["quick", "normal", "deep"]
+OutcomeKind = Literal["skip", "decision", "procedure", "summary", "fact", "warning"]
+MemoryOutcomeKind = Literal["decision", "procedure", "summary", "fact", "warning"]
 
 
 @dataclass(frozen=True)
@@ -23,8 +26,72 @@ class CodingTaskContext:
     mode: TaskMode
 
 
+@dataclass(frozen=True)
+class CodingOutcome:
+    """Durable outcome candidate produced by a coding-agent task."""
+
+    memory_id: str
+    scope: str
+    title: str
+    summary: str
+    detail: str
+    kind_hint: OutcomeKind | None = None
+    reusable: bool = False
+    architecture_relevant: bool = False
+    recurring_failure: bool = False
+    stable_fact: bool = False
+    session_summary: bool = False
+    low_signal: bool = False
+    should_pin: bool = False
+    pin_reason: str | None = None
+    importance: int | None = None
+    confidence: int = 100
+    tags: list[str] = field(default_factory=list)
+    entities: list[str] = field(default_factory=list)
+    source_tool: str | None = None
+    source_session_id: str | None = None
+    source_ref: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OutcomeClassification:
+    """Classification result for a coding outcome."""
+
+    kind: OutcomeKind
+    reason: str
+    importance: int | None = None
+    pin_reason: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class StoredOutcomeResult:
+    """Result of attempting to store a classified coding outcome."""
+
+    stored: bool
+    classification: OutcomeClassification
+    memory: object | None = None
+
+
 class CodingAgentAdapter(BaseAdapter):
     """Workflow helpers for coding agents working on implementation tasks."""
+
+    @staticmethod
+    def repo_scope(repo: str) -> str:
+        return f"repo:{CodingAgentAdapter._slug(repo)}"
+
+    @staticmethod
+    def workspace_scope(workspace: str) -> str:
+        return f"workspace:{CodingAgentAdapter._slug(workspace)}"
+
+    @staticmethod
+    def session_scope(session_id: str) -> str:
+        return f"session:{CodingAgentAdapter._slug(session_id)}"
+
+    @staticmethod
+    def task_scope(repo: str, task_id: str) -> str:
+        return f"task:{CodingAgentAdapter._slug(repo)}-{CodingAgentAdapter._slug(task_id)}"
 
     def start_task(
         self,
@@ -121,6 +188,94 @@ class CodingAgentAdapter(BaseAdapter):
 
     def stage_import(self, source):
         self._client.import_store(source)
+
+    def classify_outcome(self, outcome: CodingOutcome) -> OutcomeClassification:
+        if outcome.kind_hint is not None:
+            return self._classification_for_explicit_hint(outcome)
+
+        if outcome.low_signal:
+            return OutcomeClassification(
+                kind="skip",
+                reason="Outcome marked as low-signal and should not be stored.",
+            )
+
+        if outcome.architecture_relevant:
+            return OutcomeClassification(
+                kind="decision",
+                reason="Architecture-relevant outcomes should be stored as decisions.",
+                importance=outcome.importance or 90,
+                pin_reason=outcome.pin_reason or self._default_pin_reason(outcome, "decision"),
+                tags=["coding", "decision", *outcome.tags],
+            )
+
+        if outcome.recurring_failure:
+            return OutcomeClassification(
+                kind="warning",
+                reason="Recurring failures should be stored as warnings.",
+                importance=outcome.importance or 85,
+                pin_reason=outcome.pin_reason if outcome.should_pin else None,
+                tags=["coding", "pitfall", *outcome.tags],
+            )
+
+        if outcome.session_summary:
+            return OutcomeClassification(
+                kind="summary",
+                reason="Session rollups should be stored as summaries.",
+                importance=outcome.importance or 75,
+                pin_reason=outcome.pin_reason if outcome.should_pin else None,
+                tags=["coding", "summary", *outcome.tags],
+            )
+
+        if outcome.stable_fact:
+            return OutcomeClassification(
+                kind="fact",
+                reason="Stable project facts should be stored as facts.",
+                importance=outcome.importance or 70,
+                pin_reason=outcome.pin_reason if outcome.should_pin else None,
+                tags=["coding", "fact", *outcome.tags],
+            )
+
+        if outcome.reusable:
+            return OutcomeClassification(
+                kind="procedure",
+                reason="Reusable implementation steps should be stored as procedures.",
+                importance=outcome.importance or 80,
+                pin_reason=outcome.pin_reason if outcome.should_pin else None,
+                tags=["coding", "procedure", *outcome.tags],
+            )
+
+        return OutcomeClassification(
+            kind="skip",
+            reason="Outcome did not indicate durable signal worth storing.",
+        )
+
+    def store_outcome(self, outcome: CodingOutcome) -> StoredOutcomeResult:
+        classification = self.classify_outcome(outcome)
+        if classification.kind == "skip":
+            return StoredOutcomeResult(stored=False, classification=classification)
+
+        memory = self._remember(
+            memory_id=outcome.memory_id,
+            scope=outcome.scope,
+            kind=classification.kind,
+            title=outcome.title,
+            summary=outcome.summary,
+            detail=outcome.detail,
+            importance=classification.importance or 50,
+            confidence=outcome.confidence,
+            tags=classification.tags,
+            entities=outcome.entities,
+            pin_reason=classification.pin_reason,
+            source_tool=outcome.source_tool or "coding-agent",
+            source_session_id=outcome.source_session_id,
+            source_ref=outcome.source_ref,
+            metadata=outcome.metadata,
+        )
+        return StoredOutcomeResult(
+            stored=True,
+            classification=classification,
+            memory=memory,
+        )
 
     def store_decision(
         self,
@@ -229,12 +384,62 @@ class CodingAgentAdapter(BaseAdapter):
             source_tool="coding-agent",
         )
 
+    def _classification_for_explicit_hint(
+        self, outcome: CodingOutcome
+    ) -> OutcomeClassification:
+        if outcome.kind_hint == "skip":
+            return OutcomeClassification(
+                kind="skip",
+                reason="Outcome explicitly marked to skip writeback.",
+            )
+
+        base_tags = {
+            "decision": ["coding", "decision"],
+            "procedure": ["coding", "procedure"],
+            "summary": ["coding", "summary"],
+            "fact": ["coding", "fact"],
+            "warning": ["coding", "pitfall"],
+        }[outcome.kind_hint]
+        default_importance = {
+            "decision": 90,
+            "procedure": 80,
+            "summary": 75,
+            "fact": 70,
+            "warning": 85,
+        }[outcome.kind_hint]
+        pin_reason = outcome.pin_reason if outcome.should_pin or outcome.pin_reason else None
+        if outcome.kind_hint == "decision" and outcome.should_pin:
+            pin_reason = outcome.pin_reason or self._default_pin_reason(outcome, "decision")
+
+        return OutcomeClassification(
+            kind=outcome.kind_hint,
+            reason=f"Outcome explicitly classified as {outcome.kind_hint}.",
+            importance=outcome.importance or default_importance,
+            pin_reason=pin_reason,
+            tags=[*base_tags, *outcome.tags],
+        )
+
     def _task_mode_config(self, mode: TaskMode) -> tuple[str, int]:
         if mode == "quick":
             return ("summary_only", 6)
         if mode == "deep":
             return ("full", 12)
         return ("summary_then_pinned", 8)
+
+    def _default_pin_reason(
+        self, outcome: CodingOutcome, kind: MemoryOutcomeKind
+    ) -> str | None:
+        if not outcome.should_pin and outcome.pin_reason is None:
+            return None
+        if kind == "decision":
+            return outcome.pin_reason or "Pinned coding-agent decision"
+        return outcome.pin_reason or "Pinned coding-agent memory"
+
+    @staticmethod
+    def _slug(value: str) -> str:
+        slug = re.sub(r"[^a-z0-9-]+", "-", value.lower())
+        slug = re.sub(r"-{2,}", "-", slug).strip("-")
+        return slug or "default"
 
     def _render_task_briefing(self, *, recall, pins, recent_history) -> str:
         lines = [recall.prompt_preamble]

--- a/adapters/tests/test_host_adapters.py
+++ b/adapters/tests/test_host_adapters.py
@@ -14,6 +14,7 @@ from adapters import (  # noqa: E402
     ChatAssistantAdapter,
     CiBotAdapter,
     CodingAgentAdapter,
+    CodingOutcome,
     ReviewToolAdapter,
 )
 from mnemix.models import (  # noqa: E402
@@ -185,6 +186,13 @@ def test_coding_agent_store_decision_uses_decision_kind(
     assert req.source_tool == "coding-agent"
 
 
+def test_coding_agent_scope_helpers_normalize_values() -> None:
+    assert CodingAgentAdapter.repo_scope("Mnemix Core") == "repo:mnemix-core"
+    assert CodingAgentAdapter.workspace_scope("Release Prep") == "workspace:release-prep"
+    assert CodingAgentAdapter.session_scope("Session 42") == "session:session-42"
+    assert CodingAgentAdapter.task_scope("Mnemix Core", "Fix Recall") == "task:mnemix-core-fix-recall"
+
+
 def test_coding_agent_supports_search_and_show(mock_client: MagicMock) -> None:
     adapter = _build(CodingAgentAdapter, mock_client)
 
@@ -218,6 +226,103 @@ def test_coding_agent_exposes_checkpoint_restore_and_maintenance(
     mock_client.versions.assert_called_once_with(limit=5)
     mock_client.export.assert_called_once_with("/tmp/exported-store")
     mock_client.import_store.assert_called_once_with("/tmp/source-store")
+
+
+def test_coding_agent_classifies_low_signal_outcome_as_skip(
+    mock_client: MagicMock,
+) -> None:
+    adapter = _build(CodingAgentAdapter, mock_client)
+
+    outcome = CodingOutcome(
+        memory_id="memory:skip-1",
+        scope="repo:mnemix",
+        title="Edited one file",
+        summary="Made a small local edit.",
+        detail="This was a trivial change with no durable learning.",
+        low_signal=True,
+    )
+
+    classification = adapter.classify_outcome(outcome)
+    stored = adapter.store_outcome(outcome)
+
+    assert classification.kind == "skip"
+    assert stored.stored is False
+    mock_client.remember.assert_not_called()
+
+
+def test_coding_agent_classifies_architecture_outcome_as_decision(
+    mock_client: MagicMock,
+) -> None:
+    adapter = _build(CodingAgentAdapter, mock_client)
+
+    outcome = CodingOutcome(
+        memory_id="memory:decision-2",
+        scope="repo:mnemix",
+        title="Keep policy in adapters",
+        summary="Workflow policy belongs in host adapters.",
+        detail="The base client should remain generic while adapters hold host-specific judgment.",
+        architecture_relevant=True,
+        should_pin=True,
+    )
+
+    classification = adapter.classify_outcome(outcome)
+
+    assert classification.kind == "decision"
+    assert classification.pin_reason == "Pinned coding-agent decision"
+    assert "decision" in classification.tags
+
+
+def test_coding_agent_store_outcome_uses_inferred_kind_and_metadata(
+    mock_client: MagicMock,
+) -> None:
+    adapter = _build(CodingAgentAdapter, mock_client)
+
+    result = adapter.store_outcome(
+        CodingOutcome(
+            memory_id="memory:procedure-2",
+            scope="repo:mnemix",
+            title="Checkpoint before risky migrations",
+            summary="Create a checkpoint before large state-changing work.",
+            detail="This keeps restore straightforward if the migration writes low-signal memories.",
+            reusable=True,
+            tags=["migration"],
+            entities=["Mnemix"],
+            source_session_id="session:abc",
+            source_ref="docs/mnemix-roadmap.md",
+            metadata={"files_touched": "adapters/coding_agent_adapter.py"},
+        )
+    )
+
+    req = mock_client.remember.call_args[0][0]
+    assert result.stored is True
+    assert result.classification.kind == "procedure"
+    assert req.kind == "procedure"
+    assert req.tags == ["coding", "procedure", "migration"]
+    assert req.entities == ["Mnemix"]
+    assert req.source_session_id == "session:abc"
+    assert req.source_ref == "docs/mnemix-roadmap.md"
+    assert req.metadata["files_touched"] == "adapters/coding_agent_adapter.py"
+
+
+def test_coding_agent_explicit_skip_hint_short_circuits_writeback(
+    mock_client: MagicMock,
+) -> None:
+    adapter = _build(CodingAgentAdapter, mock_client)
+
+    result = adapter.store_outcome(
+        CodingOutcome(
+            memory_id="memory:skip-2",
+            scope="repo:mnemix",
+            title="Do not store this",
+            summary="Explicit skip outcome.",
+            detail="Caller already decided this is not durable.",
+            kind_hint="skip",
+        )
+    )
+
+    assert result.stored is False
+    assert result.classification.reason == "Outcome explicitly marked to skip writeback."
+    mock_client.remember.assert_not_called()
 
 
 def test_chat_assistant_store_preference_pins_preference(

--- a/docs_site/src/guide/host-adapters.md
+++ b/docs_site/src/guide/host-adapters.md
@@ -62,7 +62,7 @@ adapter = CodingAgentAdapter(store=Path(".mnemix"))
 adapter.ensure_store()
 
 context = adapter.start_task(
-    scope="repo:mnemix",
+    scope=adapter.repo_scope("mnemix"),
     task_title="Add host-specific adapter docs",
     mode="deep",
 )
@@ -77,8 +77,11 @@ Use coding-agent writeback for:
 
 The coding adapter also exposes:
 
+- scope helpers with `repo_scope(...)`, `workspace_scope(...)`, `session_scope(...)`, and `task_scope(...)`
 - targeted search with `search_memory(...)`
 - full memory inspection with `load_memory(...)`
+- typed classification with `classify_outcome(...)`
+- policy-driven writeback with `store_outcome(...)`
 - explicit pin and history review through task-start context assembly
 - pre-change checkpoints with `checkpoint_before_risky_change(...)`
 - version inspection and restore
@@ -88,11 +91,17 @@ The coding adapter also exposes:
 
 | Method | Purpose |
 |---|---|
+| `repo_scope(...)` | Build a standard repository scope |
+| `workspace_scope(...)` | Build a standard workspace scope |
+| `session_scope(...)` | Build a standard session scope |
+| `task_scope(...)` | Build a standard task scope |
 | `start_task(...)` | Assemble task-start context with recall, pins, and recent history |
 | `search_memory(...)` | Run targeted search during implementation work |
 | `load_memory(...)` | Inspect one memory in full detail |
 | `list_pins(...)` | View pinned memory for the current repo or scope |
 | `review_recent_memory(...)` | Inspect recent memory activity |
+| `classify_outcome(...)` | Classify a coding outcome as skip/decision/procedure/summary/fact/warning |
+| `store_outcome(...)` | Apply classification and write back only durable outcomes |
 | `checkpoint_before_risky_change(...)` | Create a safety checkpoint before risky work |
 | `list_versions(...)` | Inspect store version history |
 | `restore_checkpoint(...)` | Restore to a named checkpoint |
@@ -214,3 +223,10 @@ the adapter for the specific host.
 
 That gives each host the right memory behavior without turning the product API
 into a grab bag of use-case-specific flags.
+
+## Ecosystem template
+
+If you want a more comprehensive coding-agent adapter and reusable memory-policy
+template, see the `mnemix-context` universal Mnemix template:
+
+[mnemix-context/templates/universal/mnemix](https://github.com/micahcourey/mnemix-context/tree/main/templates/universal/mnemix)

--- a/docs_site/src/guide/index.md
+++ b/docs_site/src/guide/index.md
@@ -95,6 +95,12 @@ mnemix --store .mnemix search --text "persistent agent memory" --scope repo:mnem
 - The [Host Adapters](/guide/host-adapters) page shows how to shape recall and writeback for coding, chat, CI, and review workflows.
 - The [storage foundation](/guide/lancedb) explains why Mnemix uses LanceDB and Lance underneath.
 
+## Ecosystem
+
+Mnemix is also part of a broader toolchain. For config-driven, multi-platform
+generation of AI coding resources, see
+[mnemix-context](https://github.com/micahcourey/mnemix-context).
+
 ## Next steps
 
 - Read [Memory Model](/guide/memory-model) for the shape of stored records.

--- a/examples/agent-memory-layer/agent_wrapper.py
+++ b/examples/agent-memory-layer/agent_wrapper.py
@@ -15,13 +15,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from mnemix import Mnemix
-from mnemix.models import RecallRequest, RememberRequest
+from adapters import CodingAgentAdapter, CodingOutcome
 
 
 @dataclass(frozen=True)
 class AgentTask:
-    scope: str
+    repo_name: str
     title: str
     prompt: str
     trivial: bool = False
@@ -39,8 +38,8 @@ class AgentMemoryLayer:
     """Wraps an agent runtime with selective Mnemix recall and writeback."""
 
     def __init__(self, store: Path | str = Path(".mnemix")) -> None:
-        self._client = Mnemix(store=store)
-        self._client.init()
+        self._adapter = CodingAgentAdapter(store=store)
+        self._adapter.ensure_store()
 
     def run_task(self, task: AgentTask) -> AgentResult:
         context_block = ""
@@ -56,19 +55,11 @@ class AgentMemoryLayer:
         return result
 
     def _build_context_block(self, task: AgentTask) -> str:
-        recalled = self._client.recall(
-            RecallRequest(
-                scope=task.scope,
-                text=task.title,
-                disclosure_depth="summary_then_pinned",
-                limit=8,
-            )
+        context = self._adapter.start_task(
+            scope=self._adapter.repo_scope(task.repo_name),
+            task_title=task.title,
         )
-
-        lines: list[str] = []
-        for entry in [*recalled.pinned_context, *recalled.summaries]:
-            lines.append(f"- [{entry.layer}] {entry.memory.title}: {entry.memory.summary}")
-        return "\n".join(lines)
+        return context.prompt_preamble
 
     def _compose_prompt(self, prompt: str, context_block: str) -> str:
         if not context_block:
@@ -111,15 +102,14 @@ class AgentMemoryLayer:
             .replace(":", "-")
         )
 
-        self._client.remember(
-            RememberRequest(
-                id=f"memory:{memory_id}",
-                scope=task.scope,
-                kind="procedure",
+        self._adapter.store_outcome(
+            CodingOutcome(
+                memory_id=f"memory:{memory_id}",
+                scope=self._adapter.repo_scope(task.repo_name),
                 title=task.title,
                 summary=result.durable_summary,
                 detail=result.durable_detail,
-                importance=80,
+                reusable=True,
                 tags=["agents", "memory"],
                 source_tool="agent-wrapper",
             )
@@ -130,7 +120,7 @@ if __name__ == "__main__":
     layer = AgentMemoryLayer()
     result = layer.run_task(
         AgentTask(
-            scope="repo:mnemix",
+            repo_name="mnemix",
             title="Use Mnemix selectively in agent workflows",
             prompt="Draft project guidance for intelligent memory usage.",
         )

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,5 +1,6 @@
 import Header from './components/Header';
 import Hero from './components/Hero';
+import Ecosystem from './components/Ecosystem';
 import Features from './components/Features';
 import HowItWorks from './components/HowItWorks';
 import Footer from './components/Footer';
@@ -12,6 +13,7 @@ function App() {
       <main>
         <Hero />
         <Features />
+        <Ecosystem />
         <HowItWorks />
       </main>
       <Footer />

--- a/website/src/components/Ecosystem.tsx
+++ b/website/src/components/Ecosystem.tsx
@@ -1,0 +1,126 @@
+import { Blocks, ExternalLink, Sparkles } from 'lucide-react';
+
+export default function Ecosystem() {
+    return (
+        <section id="ecosystem" style={styles.section}>
+            <div className="container" style={styles.container}>
+                <div className="glass-card" style={styles.card}>
+                    <div style={styles.copy}>
+                        <div style={styles.eyebrow}>
+                            <Sparkles size={16} />
+                            Ecosystem
+                        </div>
+                        <h2 style={styles.title}>
+                            Mnemix pairs with <span className="text-gradient">mnemix-context</span>
+                        </h2>
+                        <p style={styles.body}>
+                            For config-driven, multi-platform generation of AI coding resources,
+                            use <a href="https://github.com/micahcourey/mnemix-context" target="_blank" rel="noreferrer" style={styles.link}>mnemix-context</a>.
+                            It complements Mnemix by generating reusable instructions, prompts,
+                            skills, and coding-agent resources around your local memory workflow.
+                        </p>
+                        <p style={styles.body}>
+                            The universal Mnemix template includes a more comprehensive coding-agent
+                            adapter and agent memory policy:
+                        </p>
+                        <a
+                            href="https://github.com/micahcourey/mnemix-context/tree/main/templates/universal/mnemix"
+                            target="_blank"
+                            rel="noreferrer"
+                            className="btn btn-secondary"
+                            style={styles.button}
+                        >
+                            <Blocks size={18} />
+                            Explore the template
+                            <ExternalLink size={16} />
+                        </a>
+                    </div>
+
+                    <div style={styles.metaPanel}>
+                        <div style={styles.metaBadge}>Companion project</div>
+                        <ul style={styles.list}>
+                            <li style={styles.listItem}>Config-driven agent resource generation</li>
+                            <li style={styles.listItem}>Portable prompts, skills, and instructions</li>
+                            <li style={styles.listItem}>Reusable coding-agent memory policy templates</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+const styles = {
+    section: {
+        padding: '2rem 0 8rem',
+    },
+    container: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+    },
+    card: {
+        display: 'grid',
+        gridTemplateColumns: '1.4fr 0.9fr',
+        gap: '2rem',
+        alignItems: 'stretch',
+        background: 'linear-gradient(135deg, rgba(20,184,166,0.08) 0%, rgba(255,255,255,0.03) 100%)',
+    },
+    copy: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '1rem',
+    },
+    eyebrow: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        color: 'var(--color-primary)',
+        fontSize: '0.9rem',
+        fontWeight: 600,
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.08em',
+    },
+    title: {
+        marginBottom: '0.25rem',
+    },
+    body: {
+        color: 'var(--color-text-muted)',
+        fontSize: '1.05rem',
+        lineHeight: 1.7,
+        maxWidth: '56ch',
+    },
+    link: {
+        color: 'var(--color-primary)',
+        textDecoration: 'none',
+    },
+    button: {
+        marginTop: '0.5rem',
+        width: 'fit-content',
+    },
+    metaPanel: {
+        borderLeft: '1px solid rgba(255,255,255,0.08)',
+        paddingLeft: '2rem',
+        display: 'flex',
+        flexDirection: 'column' as const,
+        justifyContent: 'center',
+        gap: '1rem',
+    },
+    metaBadge: {
+        color: 'var(--color-primary)',
+        fontSize: '0.85rem',
+        fontWeight: 600,
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.08em',
+    },
+    list: {
+        margin: 0,
+        paddingLeft: '1.25rem',
+        color: 'var(--color-text)',
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '0.75rem',
+    },
+    listItem: {
+        lineHeight: 1.6,
+    },
+};


### PR DESCRIPTION
## Summary
- expand `CodingAgentAdapter` into a first-class policy surface with scope helpers, typed outcomes, classification, explicit skip behavior, and `store_outcome(...)`
- extend adapter tests and the agent memory wrapper example to exercise the new coding-agent workflow
- add ecosystem callouts for `mnemix-context` in the README, docs site, and marketing website

## Verification
- `python3 -m py_compile adapters/__init__.py adapters/_adapter_base.py adapters/coding_agent_adapter.py adapters/chat_assistant_adapter.py adapters/ci_bot_adapter.py adapters/review_tool_adapter.py adapters/tests/test_host_adapters.py examples/agent-memory-layer/agent_wrapper.py`
- `pytest` not available in this environment

## Tracking
- Dex task: `74cjp1ic`
- GitHub issue: #65