### PR TITLE
feat(website): improve ecosystem section content and mobile styling

### DIFF
--- a/website/src/components/Ecosystem.tsx
+++ b/website/src/components/Ecosystem.tsx
@@ -4,7 +4,7 @@ export default function Ecosystem() {
     return (
         <section id="ecosystem" style={styles.section}>
             <div className="container" style={styles.container}>
-                <div className="glass-card" style={styles.card}>
+                <div className="glass-card ecosystem-card">
                     <div style={styles.copy}>
                         <div style={styles.eyebrow}>
                             <Sparkles size={16} />
@@ -16,32 +16,30 @@ export default function Ecosystem() {
                         <p style={styles.body}>
                             For config-driven, multi-platform generation of AI coding resources,
                             use <a href="https://github.com/micahcourey/mnemix-context" target="_blank" rel="noreferrer" style={styles.link}>mnemix-context</a>.
-                            It complements Mnemix by generating reusable instructions, prompts,
-                            skills, and coding-agent resources around your local memory workflow.
+                            It generates pre-configured AI agents, auto-activating skills, and platform adapters tailored to your entire repository.
                         </p>
                         <p style={styles.body}>
-                            The universal Mnemix template includes a more comprehensive coding-agent
-                            adapter and agent memory policy:
+                            Mnemix Context dynamically integrates with GitHub Copilot, Cursor, Claude Code, Cline, and Windsurf, acting as the bridge between your local memory engine and your favorite AI assistant.
                         </p>
                         <a
-                            href="https://github.com/micahcourey/mnemix-context/tree/main/templates/universal/mnemix"
+                            href="https://github.com/micahcourey/mnemix-context"
                             target="_blank"
                             rel="noreferrer"
                             className="btn btn-secondary"
                             style={styles.button}
                         >
                             <Blocks size={18} />
-                            Explore the template
+                            Explore mnemix-context
                             <ExternalLink size={16} />
                         </a>
                     </div>
 
-                    <div style={styles.metaPanel}>
+                    <div className="ecosystem-meta">
                         <div style={styles.metaBadge}>Companion project</div>
                         <ul style={styles.list}>
-                            <li style={styles.listItem}>Config-driven agent resource generation</li>
-                            <li style={styles.listItem}>Portable prompts, skills, and instructions</li>
-                            <li style={styles.listItem}>Reusable coding-agent memory policy templates</li>
+                            <li style={styles.listItem}>Auto-generates context files by parsing your codebase schema and architecture</li>
+                            <li style={styles.listItem}>Pre-configured Architect, Engineer, Reviewer, and Documentation agent personas</li>
+                            <li style={styles.listItem}>Universal compatibility with native adapters for 7 leading AI tools</li>
                         </ul>
                     </div>
                 </div>
@@ -57,13 +55,6 @@ const styles = {
     container: {
         display: 'flex',
         flexDirection: 'column' as const,
-    },
-    card: {
-        display: 'grid',
-        gridTemplateColumns: '1.4fr 0.9fr',
-        gap: '2rem',
-        alignItems: 'stretch',
-        background: 'linear-gradient(135deg, rgba(20,184,166,0.08) 0%, rgba(255,255,255,0.03) 100%)',
     },
     copy: {
         display: 'flex',
@@ -96,14 +87,6 @@ const styles = {
     button: {
         marginTop: '0.5rem',
         width: 'fit-content',
-    },
-    metaPanel: {
-        borderLeft: '1px solid rgba(255,255,255,0.08)',
-        paddingLeft: '2rem',
-        display: 'flex',
-        flexDirection: 'column' as const,
-        justifyContent: 'center',
-        gap: '1rem',
     },
     metaBadge: {
         color: 'var(--color-primary)',

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -177,6 +177,38 @@ a:hover {
   }
 }
 
+/* Ecosystem Card */
+.ecosystem-card {
+  display: grid;
+  grid-template-columns: 1.4fr 0.9fr;
+  gap: 2rem;
+  align-items: stretch;
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.08) 0%, rgba(255, 255, 255, 0.03) 100%);
+}
+
+.ecosystem-meta {
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  padding-left: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+@media (max-width: 900px) {
+  .ecosystem-card {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .ecosystem-meta {
+    border-left: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-left: 0;
+    padding-top: 1.5rem;
+  }
+}
+
 /* Animations */
 @keyframes fadeIn {
   from {


### PR DESCRIPTION
## Description
Refines the new `Ecosystem` section on the marketing site to better represent the `mnemix-context` companion project and ensure a flawless mobile experience.

### Changes Made
- **Responsive Layout:** Replaced inline grid styles with responsive CSS classes (`.ecosystem-card`, `.ecosystem-meta`) that stack gracefully on mobile devices.
- **Content Polish:** Rewrote the descriptive copy and bullet points to highlight `mnemix-context`'s key capabilities (schema parsing, pre-configured personas, platform adapters).
- **CTA Routing:** Updated the primary call-to-action to link to the main `mnemix-context` repository instead of standard templates.