### PR TITLE
Add website and docs links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ AI coding agents have no continuous memory. Every session starts cold. Mnemix ch
 
 No cloud, no daemon, no configuration sprawl. Just a local store on your filesystem that your agent can write to and read from, with a clean CLI and Python client sitting on top.
 
+Website: [mnemix.org](https://mnemix.org)  
+Docs: [docs.mnemix.org](https://docs.mnemix.org)
+
 ---
 
 ## Ecosystem


### PR DESCRIPTION
## Summary
- add explicit links to `mnemix.org` and `docs.mnemix.org` near the top of the README
- make the primary website and documentation entry points visible in the main project description

## Verification
- verified the new links are present in `README.md`
- left local `.dex` sync-state changes out of this PR