### PR TITLE
fix(deps): clear lz4 advisory in lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex 0.12.0",
+ "lz4_flex 0.12.1",
  "zstd",
 ]
 
@@ -4063,15 +4063,15 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 dependencies = [
  "twox-hash",
 ]
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "mnemix-cli"
-version = "0.2.0"
+version = "0.2.9"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "mnemix-core"
-version = "0.2.0"
+version = "0.2.9"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "mnemix-lancedb"
-version = "0.2.0"
+version = "0.2.9"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4218,11 +4218,11 @@ dependencies = [
 
 [[package]]
 name = "mnemix-test-support"
-version = "0.2.0"
+version = "0.2.9"
 
 [[package]]
 name = "mnemix-types"
-version = "0.2.0"
+version = "0.2.9"
 dependencies = [
  "serde",
 ]
@@ -6048,7 +6048,7 @@ dependencies = [
  "levenshtein_automata",
  "log",
  "lru",
- "lz4_flex 0.11.5",
+ "lz4_flex 0.11.6",
  "measure_time",
  "memmap2",
  "once_cell",


### PR DESCRIPTION
## Findings
- cargo deny failed in the checks job on RUSTSEC-2026-0041
- the vulnerable crates were transitive lz4_flex 0.11.5 and 0.12.0 pulled in through tantivy/arrow under lance and lancedb
- this is resolvable with a lockfile-only update

## Summary
- update lz4_flex 0.11.5 -> 0.11.6
- update lz4_flex 0.12.0 -> 0.12.1
- refresh stale workspace package versions in Cargo.lock to 0.2.9

## Verification
- cargo deny check advisories
- cargo deny check
- cargo build --locked -p mnemix-cli (started; long-running compile after advisory fix)