### PR TITLE
codex-gpt-5/feat/001-policy-runner-follow-ons: complete policy runner workstream 001

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -22,6 +22,8 @@ the primary host workflow. It now covers:
 - scope helpers for repo, workspace, session, and task namespaces
 - task-start recall modes (`quick`, `normal`, `deep`)
 - pinned-memory and recent-history context assembly
+- policy check, explain, record, clear, and cleanup helpers
+- policy-aware task start, checkpoint, and writeback evidence recording
 - targeted search and memory inspection
 - typed outcome classification with an explicit skip path
 - `store_outcome(...)` for policy-driven writeback

--- a/adapters/coding_agent_adapter.py
+++ b/adapters/coding_agent_adapter.py
@@ -6,7 +6,15 @@ import re
 from dataclasses import dataclass, field
 from typing import Literal
 
-from mnemix.models import OptimizeRequest, RestoreRequest
+from mnemix.models import (
+    OptimizeRequest,
+    PolicyCheckRequest,
+    PolicyCleanupRequest,
+    PolicyClearRequest,
+    PolicyDecisionResult,
+    PolicyRecordRequest,
+    RestoreRequest,
+)
 
 from ._adapter_base import BaseAdapter, ContextBundle
 
@@ -24,6 +32,9 @@ class CodingTaskContext:
     recent_history: list
     prompt_preamble: str
     mode: TaskMode
+    workflow_key: str | None = None
+    policy_decision: PolicyDecisionResult | None = None
+    policy_recorded_actions: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -72,6 +83,7 @@ class StoredOutcomeResult:
     stored: bool
     classification: OutcomeClassification
     memory: object | None = None
+    policy_recorded_actions: list[str] = field(default_factory=list)
 
 
 class CodingAgentAdapter(BaseAdapter):
@@ -102,6 +114,9 @@ class CodingAgentAdapter(BaseAdapter):
         recall_limit: int | None = None,
         pin_limit: int = 10,
         history_limit: int = 5,
+        workflow_key: str | None = None,
+        task_kind: str | None = None,
+        paths: list[str] | None = None,
     ) -> CodingTaskContext:
         disclosure_depth, default_limit = self._task_mode_config(mode)
         recall = self._context_bundle(
@@ -113,6 +128,18 @@ class CodingAgentAdapter(BaseAdapter):
         )
         pins = self.list_pins(scope=scope, limit=pin_limit)
         recent_history = self.review_recent_memory(scope=scope, limit=history_limit)
+        policy_recorded_actions: list[str] = []
+        policy_decision = None
+        if workflow_key is not None:
+            self.record_policy_action(workflow_key=workflow_key, action="recall")
+            policy_recorded_actions.append("recall")
+            policy_decision = self.explain_policy(
+                trigger="on_task_start",
+                workflow_key=workflow_key,
+                scope=scope,
+                task_kind=task_kind,
+                paths=paths or [],
+            )
         return CodingTaskContext(
             recall=recall,
             pins=pins,
@@ -123,6 +150,9 @@ class CodingAgentAdapter(BaseAdapter):
                 recent_history=recent_history,
             ),
             mode=mode,
+            workflow_key=workflow_key,
+            policy_decision=policy_decision,
+            policy_recorded_actions=policy_recorded_actions,
         )
 
     def search_memory(
@@ -158,11 +188,15 @@ class CodingAgentAdapter(BaseAdapter):
         *,
         task_id: str,
         description: str | None = None,
+        workflow_key: str | None = None,
     ):
-        return self.create_checkpoint(
+        checkpoint = self.create_checkpoint(
             f"task-{task_id}",
             description=description or "Checkpoint before risky coding-agent change",
         )
+        if workflow_key is not None:
+            self.record_policy_action(workflow_key=workflow_key, action="checkpoint")
+        return checkpoint
 
     def list_versions(self, *, limit: int = 20):
         return self._client.versions(limit=limit)
@@ -249,7 +283,92 @@ class CodingAgentAdapter(BaseAdapter):
             reason="Outcome did not indicate durable signal worth storing.",
         )
 
-    def store_outcome(self, outcome: CodingOutcome) -> StoredOutcomeResult:
+    def check_policy(
+        self,
+        *,
+        trigger: str,
+        workflow_key: str | None = None,
+        task_kind: str | None = None,
+        scope: str | None = None,
+        paths: list[str] | None = None,
+    ) -> PolicyDecisionResult:
+        return self._client.policy_check(
+            PolicyCheckRequest(
+                trigger=trigger,
+                workflow_key=workflow_key,
+                host="coding-agent",
+                task_kind=task_kind,
+                scope=scope,
+                paths=paths or [],
+            )
+        )
+
+    def explain_policy(
+        self,
+        *,
+        trigger: str,
+        workflow_key: str | None = None,
+        task_kind: str | None = None,
+        scope: str | None = None,
+        paths: list[str] | None = None,
+    ) -> PolicyDecisionResult:
+        return self._client.policy_explain(
+            PolicyCheckRequest(
+                trigger=trigger,
+                workflow_key=workflow_key,
+                host="coding-agent",
+                task_kind=task_kind,
+                scope=scope,
+                paths=paths or [],
+            )
+        )
+
+    def record_policy_action(
+        self,
+        *,
+        workflow_key: str,
+        action: str,
+        reason: str | None = None,
+    ):
+        return self._client.policy_record(
+            PolicyRecordRequest(
+                workflow_key=workflow_key,
+                action=action,
+                reason=reason,
+            )
+        )
+
+    def clear_policy_workflow(
+        self,
+        *,
+        workflow_key: str,
+        action: str | None = None,
+    ):
+        return self._client.policy_clear(
+            PolicyClearRequest(workflow_key=workflow_key, action=action)
+        )
+
+    def cleanup_policy_state(
+        self,
+        *,
+        ttl: str | None = None,
+        older_than: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._client.policy_cleanup(
+            PolicyCleanupRequest(
+                ttl=ttl,
+                older_than=older_than,
+                dry_run=dry_run,
+            )
+        )
+
+    def store_outcome(
+        self,
+        outcome: CodingOutcome,
+        *,
+        workflow_key: str | None = None,
+    ) -> StoredOutcomeResult:
         classification = self.classify_outcome(outcome)
         if classification.kind == "skip":
             return StoredOutcomeResult(stored=False, classification=classification)
@@ -271,10 +390,19 @@ class CodingAgentAdapter(BaseAdapter):
             source_ref=outcome.source_ref,
             metadata=outcome.metadata,
         )
+        policy_recorded_actions: list[str] = []
+        if workflow_key is not None:
+            self.record_policy_action(
+                workflow_key=workflow_key,
+                action="classification_selected",
+            )
+            self.record_policy_action(workflow_key=workflow_key, action="writeback")
+            policy_recorded_actions = ["classification_selected", "writeback"]
         return StoredOutcomeResult(
             stored=True,
             classification=classification,
             memory=memory,
+            policy_recorded_actions=policy_recorded_actions,
         )
 
     def store_decision(

--- a/adapters/tests/test_host_adapters.py
+++ b/adapters/tests/test_host_adapters.py
@@ -112,7 +112,6 @@ _STATS = StoreStats(
     latest_checkpoint="ci-123",
 )
 
-
 @pytest.fixture()
 def mock_client() -> MagicMock:
     client = MagicMock()
@@ -136,6 +135,11 @@ def mock_client() -> MagicMock:
     client.versions.return_value = [_VERSION]
     client.restore.return_value = _RESTORE
     client.optimize.return_value = _OPTIMIZE
+    client.policy_check.return_value = MagicMock(decision="allow")
+    client.policy_explain.return_value = MagicMock(decision="allow")
+    client.policy_record.return_value = MagicMock(status="recorded")
+    client.policy_clear.return_value = MagicMock(status="cleared")
+    client.policy_cleanup.return_value = MagicMock(status="cleaned")
     return client
 
 
@@ -164,6 +168,29 @@ def test_coding_agent_start_task_uses_task_title_for_recall(
     assert "coding task" in bundle.prompt_preamble
     mock_client.pins.assert_called_once_with(scope="repo:mnemix", limit=10)
     mock_client.history.assert_called_once_with(scope="repo:mnemix", limit=5)
+
+
+def test_coding_agent_start_task_records_policy_recall_when_workflow_key_is_given(
+    mock_client: MagicMock,
+) -> None:
+    adapter = _build(CodingAgentAdapter, mock_client)
+
+    bundle = adapter.start_task(
+        scope="repo:mnemix",
+        task_title="Implement policy lifecycle",
+        workflow_key="wf-1",
+        task_kind="feature",
+        paths=["adapters/coding_agent_adapter.py"],
+    )
+
+    assert bundle.workflow_key == "wf-1"
+    assert bundle.policy_recorded_actions == ["recall"]
+    mock_client.policy_record.assert_called_once()
+    policy_req = mock_client.policy_explain.call_args[0][0]
+    assert policy_req.trigger == "on_task_start"
+    assert policy_req.workflow_key == "wf-1"
+    assert policy_req.host == "coding-agent"
+    assert policy_req.task_kind == "feature"
 
 
 def test_coding_agent_store_decision_uses_decision_kind(
@@ -226,6 +253,18 @@ def test_coding_agent_exposes_checkpoint_restore_and_maintenance(
     mock_client.versions.assert_called_once_with(limit=5)
     mock_client.export.assert_called_once_with("/tmp/exported-store")
     mock_client.import_store.assert_called_once_with("/tmp/source-store")
+
+
+def test_coding_agent_checkpoint_records_policy_evidence(
+    mock_client: MagicMock,
+) -> None:
+    adapter = _build(CodingAgentAdapter, mock_client)
+
+    adapter.checkpoint_before_risky_change(task_id="migration-1", workflow_key="wf-1")
+
+    policy_req = mock_client.policy_record.call_args[0][0]
+    assert policy_req.workflow_key == "wf-1"
+    assert policy_req.action == "checkpoint"
 
 
 def test_coding_agent_classifies_low_signal_outcome_as_skip(
@@ -302,6 +341,31 @@ def test_coding_agent_store_outcome_uses_inferred_kind_and_metadata(
     assert req.source_session_id == "session:abc"
     assert req.source_ref == "docs/mnemix-roadmap.md"
     assert req.metadata["files_touched"] == "adapters/coding_agent_adapter.py"
+
+
+def test_coding_agent_store_outcome_records_policy_writeback(
+    mock_client: MagicMock,
+) -> None:
+    adapter = _build(CodingAgentAdapter, mock_client)
+
+    result = adapter.store_outcome(
+        CodingOutcome(
+            memory_id="memory:procedure-3",
+            scope="repo:mnemix",
+            title="Store durable procedure",
+            summary="Reusable workflow.",
+            detail="Record the result after classification.",
+            reusable=True,
+        ),
+        workflow_key="wf-1",
+    )
+
+    assert result.policy_recorded_actions == ["classification_selected", "writeback"]
+    assert mock_client.policy_record.call_count == 2
+    first_req = mock_client.policy_record.call_args_list[0][0][0]
+    second_req = mock_client.policy_record.call_args_list[1][0][0]
+    assert first_req.action == "classification_selected"
+    assert second_req.action == "writeback"
 
 
 def test_coding_agent_explicit_skip_hint_short_circuits_writeback(

--- a/crates/mnemix-cli/src/cli.rs
+++ b/crates/mnemix-cli/src/cli.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use mnemix_core::{
-    CheckpointName, DisclosureDepth, EntityName, MemoryId, PolicyAction, PolicyTrigger,
-    RetrievalMode, ScopeId, SessionId, SourceRef, TagName, ToolName,
+    CheckpointName, DisclosureDepth, EntityName, EvidenceTtl, MemoryId, PolicyAction,
+    PolicyTrigger, RetrievalMode, ScopeId, SessionId, SourceRef, TagName, ToolName,
 };
 
 use crate::output::OutputFormat;
@@ -76,6 +76,8 @@ pub(crate) enum PolicyCommand {
     Check(PolicyCheckArgs),
     Explain(PolicyCheckArgs),
     Record(PolicyRecordArgs),
+    Clear(PolicyClearArgs),
+    Cleanup(PolicyCleanupArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -109,6 +111,27 @@ pub(crate) struct PolicyRecordArgs {
 
     #[arg(long)]
     pub(crate) reason: Option<String>,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct PolicyClearArgs {
+    #[arg(long)]
+    pub(crate) workflow_key: String,
+
+    #[arg(long, value_parser = parse_policy_action)]
+    pub(crate) action: Option<PolicyAction>,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct PolicyCleanupArgs {
+    #[arg(long, value_parser = parse_evidence_ttl)]
+    pub(crate) ttl: Option<EvidenceTtl>,
+
+    #[arg(long, value_parser = parse_non_empty)]
+    pub(crate) older_than: Option<String>,
+
+    #[arg(long)]
+    pub(crate) dry_run: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -575,9 +598,14 @@ fn parse_policy_action(value: &str) -> Result<PolicyAction, String> {
     value.parse()
 }
 
+fn parse_evidence_ttl(value: &str) -> Result<EvidenceTtl, String> {
+    value.parse()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{MetadataEntry, parse_metadata_entry};
+    use super::{MetadataEntry, parse_evidence_ttl, parse_metadata_entry};
+    use mnemix_core::EvidenceTtl;
 
     #[test]
     fn parse_metadata_entry_trims_surrounding_whitespace() {
@@ -588,5 +616,12 @@ mod tests {
                 value: "cli".to_owned(),
             })
         );
+    }
+
+    #[test]
+    fn parse_evidence_ttl_accepts_known_values() {
+        assert_eq!(parse_evidence_ttl("task"), Ok(EvidenceTtl::Task));
+        assert_eq!(parse_evidence_ttl("session"), Ok(EvidenceTtl::Session));
+        assert_eq!(parse_evidence_ttl("manual"), Ok(EvidenceTtl::Manual));
     }
 }

--- a/crates/mnemix-cli/src/cmd/policy.rs
+++ b/crates/mnemix-cli/src/cmd/policy.rs
@@ -36,8 +36,9 @@ struct PolicyStateFile {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 struct PolicyStateEntry {
-    #[serde(default)]
     evidence: PolicyEvidence,
+    #[serde(default)]
+    evidence_ttl: Option<EvidenceTtl>,
     #[serde(default)]
     created_at_unix: Option<u64>,
     #[serde(default)]
@@ -63,6 +64,7 @@ impl From<PolicyStateEntryCompat> for PolicyStateEntry {
             PolicyStateEntryCompat::Current(entry) => entry,
             PolicyStateEntryCompat::Legacy(evidence) => Self {
                 evidence,
+                evidence_ttl: None,
                 created_at_unix: None,
                 updated_at_unix: None,
             },
@@ -89,6 +91,10 @@ impl PolicyStateEntry {
 
     fn last_updated_unix(&self) -> Option<u64> {
         self.updated_at_unix.or(self.created_at_unix)
+    }
+
+    fn effective_ttl(&self, default_ttl: EvidenceTtl) -> EvidenceTtl {
+        self.evidence_ttl.unwrap_or(default_ttl)
     }
 }
 
@@ -133,12 +139,16 @@ fn check(
 
 fn record(store_path: &Path, args: &PolicyRecordArgs) -> Result<CommandOutput, CliError> {
     fs::create_dir_all(store_path)?;
+    let config = load_policy_config(store_path)?;
     let mut state = load_policy_state(store_path)?;
     let now_unix = current_unix_timestamp();
     let entry = state
         .workflows
         .entry(args.workflow_key.clone())
         .or_default();
+    if entry.evidence_ttl.is_none() {
+        entry.evidence_ttl = Some(config.defaults.evidence_ttl);
+    }
 
     match args.action {
         PolicyAction::SkipReason => {
@@ -189,34 +199,59 @@ fn clear(store_path: &Path, args: &PolicyClearArgs) -> Result<CommandOutput, Cli
         ));
     };
 
-    let message = if let Some(action) = args.action {
-        clear_action(&mut entry.evidence, action);
-        if entry.is_empty() {
-            format!(
-                "Cleared `{}` and removed now-empty workflow `{}`",
-                action.as_str(),
-                args.workflow_key
+    let (status, message, state_changed) = if let Some(action) = args.action {
+        let changed = clear_action(&mut entry.evidence, action);
+        if !changed {
+            state.workflows.insert(args.workflow_key.clone(), entry);
+            (
+                "unchanged",
+                format!(
+                    "No `{}` evidence was present for workflow `{}`",
+                    action.as_str(),
+                    args.workflow_key
+                ),
+                false,
+            )
+        } else if entry.is_empty() {
+            (
+                "cleared",
+                format!(
+                    "Cleared `{}` and removed now-empty workflow `{}`",
+                    action.as_str(),
+                    args.workflow_key
+                ),
+                true,
             )
         } else {
             entry.touch(current_unix_timestamp());
             state.workflows.insert(args.workflow_key.clone(), entry);
-            format!(
-                "Cleared `{}` for workflow `{}`",
-                action.as_str(),
-                args.workflow_key
+            (
+                "cleared",
+                format!(
+                    "Cleared `{}` for workflow `{}`",
+                    action.as_str(),
+                    args.workflow_key
+                ),
+                true,
             )
         }
     } else {
-        format!(
-            "Cleared all policy evidence for workflow `{}`",
-            args.workflow_key
+        (
+            "cleared",
+            format!(
+                "Cleared all policy evidence for workflow `{}`",
+                args.workflow_key
+            ),
+            true,
         )
     };
 
-    save_policy_state(store_path, &state)?;
+    if state_changed {
+        save_policy_state(store_path, &state)?;
+    }
     Ok(super::status_result(
         "policy",
-        "cleared",
+        status,
         message,
         Some(store_path.display().to_string()),
         None,
@@ -225,8 +260,8 @@ fn clear(store_path: &Path, args: &PolicyClearArgs) -> Result<CommandOutput, Cli
 
 fn cleanup(store_path: &Path, args: &PolicyCleanupArgs) -> Result<CommandOutput, CliError> {
     let config = load_policy_config(store_path)?;
-    let ttl = args.ttl.unwrap_or(config.defaults.evidence_ttl);
-    let older_than = cleanup_window(ttl, args.older_than.as_deref())?;
+    let selected_ttl = args.ttl;
+    let older_than = cleanup_window(args.older_than.as_deref())?;
     let now_unix = current_unix_timestamp();
 
     let mut state = load_policy_state(store_path)?;
@@ -235,7 +270,12 @@ fn cleanup(store_path: &Path, args: &PolicyCleanupArgs) -> Result<CommandOutput,
         if entry.is_empty() {
             return false;
         }
-        !is_expired(entry, ttl, older_than, now_unix)
+        let ttl = entry.effective_ttl(config.defaults.evidence_ttl);
+        if selected_ttl.is_some_and(|filter| ttl != filter) {
+            return true;
+        }
+        let age_threshold = older_than.or_else(|| ttl_max_age(ttl));
+        !is_expired(entry, ttl, age_threshold, now_unix)
     });
     let removed = before.saturating_sub(state.workflows.len());
 
@@ -244,15 +284,7 @@ fn cleanup(store_path: &Path, args: &PolicyCleanupArgs) -> Result<CommandOutput,
         save_policy_state(store_path, &state)?;
     }
 
-    let lifecycle = if let Some(window) = older_than {
-        format!(
-            "using `{}` TTL and `{}` age threshold",
-            ttl.as_str(),
-            humantime::format_duration(window)
-        )
-    } else {
-        format!("using `{}` TTL with empty-entry cleanup only", ttl.as_str())
-    };
+    let lifecycle = cleanup_description(selected_ttl, older_than);
 
     Ok(super::status_result(
         "policy",
@@ -354,17 +386,20 @@ fn policy_state_path(store_path: &Path) -> PathBuf {
     store_path.join(POLICY_STATE_FILENAME)
 }
 
-fn clear_action(evidence: &mut PolicyEvidence, action: PolicyAction) {
-    evidence.actions.remove(&action);
+fn clear_action(evidence: &mut PolicyEvidence, action: PolicyAction) -> bool {
+    let removed_action = evidence.actions.remove(&action);
     if matches!(action, PolicyAction::SkipReason) {
-        evidence.skip_reason = None;
+        let removed_reason = evidence.skip_reason.take().is_some();
+        return removed_action || removed_reason;
     }
+    removed_action
 }
 
 fn resolve_evidence(
     entry: &PolicyStateEntry,
-    ttl: EvidenceTtl,
+    default_ttl: EvidenceTtl,
 ) -> (Option<PolicyEvidence>, Option<String>) {
+    let ttl = entry.effective_ttl(default_ttl);
     if is_expired(entry, ttl, ttl_max_age(ttl), current_unix_timestamp()) {
         return (
             None,
@@ -378,15 +413,31 @@ fn resolve_evidence(
     (Some(entry.evidence.clone()), None)
 }
 
-fn cleanup_window(
-    ttl: EvidenceTtl,
-    older_than: Option<&str>,
-) -> Result<Option<Duration>, CliError> {
+fn cleanup_window(older_than: Option<&str>) -> Result<Option<Duration>, CliError> {
     match older_than {
         Some(value) => parse_duration(value)
             .map(Some)
             .map_err(|error| CliError::PolicyStateParse(error.to_string())),
-        None => Ok(ttl_max_age(ttl)),
+        None => Ok(None),
+    }
+}
+
+fn cleanup_description(selected_ttl: Option<EvidenceTtl>, older_than: Option<Duration>) -> String {
+    match (selected_ttl, older_than) {
+        (Some(ttl), Some(window)) => format!(
+            "for stored `{}` entries and `{}` age threshold",
+            ttl.as_str(),
+            humantime::format_duration(window)
+        ),
+        (Some(ttl), None) => format!(
+            "for stored `{}` entries using their default age threshold",
+            ttl.as_str()
+        ),
+        (None, Some(window)) => format!(
+            "using stored TTL semantics and `{}` age threshold",
+            humantime::format_duration(window)
+        ),
+        (None, None) => "using stored TTL semantics and default age thresholds".to_owned(),
     }
 }
 

--- a/crates/mnemix-cli/src/cmd/policy.rs
+++ b/crates/mnemix-cli/src/cmd/policy.rs
@@ -2,15 +2,21 @@ use std::{
     collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use humantime::parse_duration;
 use mnemix_core::{
-    PolicyAction, PolicyConfig, PolicyContext, PolicyDecision, PolicyEvidence, evaluate_policy,
+    EvidenceTtl, PolicyAction, PolicyConfig, PolicyContext, PolicyDecision, PolicyEvidence,
+    evaluate_policy,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    cli::{PolicyArgs, PolicyCheckArgs, PolicyCommand, PolicyRecordArgs},
+    cli::{
+        PolicyArgs, PolicyCheckArgs, PolicyCleanupArgs, PolicyClearArgs, PolicyCommand,
+        PolicyRecordArgs,
+    },
     cmd::policy_result,
     errors::CliError,
     output::CommandOutput,
@@ -19,11 +25,71 @@ use crate::{
 const POLICY_CONFIG_VERSION: u16 = 1;
 const POLICY_CONFIG_FILENAME: &str = "policy.toml";
 const POLICY_STATE_FILENAME: &str = "policy-state.json";
+const TASK_EVIDENCE_MAX_AGE: Duration = Duration::from_secs(6 * 60 * 60);
+const SESSION_EVIDENCE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 struct PolicyStateFile {
     #[serde(default)]
-    workflows: BTreeMap<String, PolicyEvidence>,
+    workflows: BTreeMap<String, PolicyStateEntry>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+struct PolicyStateEntry {
+    #[serde(default)]
+    evidence: PolicyEvidence,
+    #[serde(default)]
+    created_at_unix: Option<u64>,
+    #[serde(default)]
+    updated_at_unix: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+#[serde(untagged)]
+enum PolicyStateEntryCompat {
+    Current(PolicyStateEntry),
+    Legacy(PolicyEvidence),
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+struct PolicyStateFileCompat {
+    #[serde(default)]
+    workflows: BTreeMap<String, PolicyStateEntryCompat>,
+}
+
+impl From<PolicyStateEntryCompat> for PolicyStateEntry {
+    fn from(value: PolicyStateEntryCompat) -> Self {
+        match value {
+            PolicyStateEntryCompat::Current(entry) => entry,
+            PolicyStateEntryCompat::Legacy(evidence) => Self {
+                evidence,
+                created_at_unix: None,
+                updated_at_unix: None,
+            },
+        }
+    }
+}
+
+impl PolicyStateEntry {
+    fn touch(&mut self, now_unix: u64) {
+        if self.created_at_unix.is_none() {
+            self.created_at_unix = Some(now_unix);
+        }
+        self.updated_at_unix = Some(now_unix);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.evidence.actions.is_empty()
+            && self
+                .evidence
+                .skip_reason
+                .as_ref()
+                .is_none_or(|value| value.trim().is_empty())
+    }
+
+    fn last_updated_unix(&self) -> Option<u64> {
+        self.updated_at_unix.or(self.created_at_unix)
+    }
 }
 
 pub(crate) fn run(store_path: &Path, args: &PolicyArgs) -> Result<CommandOutput, CliError> {
@@ -31,6 +97,8 @@ pub(crate) fn run(store_path: &Path, args: &PolicyArgs) -> Result<CommandOutput,
         PolicyCommand::Check(args) => check(store_path, args, "check"),
         PolicyCommand::Explain(args) => check(store_path, args, "explain"),
         PolicyCommand::Record(args) => record(store_path, args),
+        PolicyCommand::Clear(args) => clear(store_path, args),
+        PolicyCommand::Cleanup(args) => cleanup(store_path, args),
     }
 }
 
@@ -41,23 +109,31 @@ fn check(
 ) -> Result<CommandOutput, CliError> {
     let config = load_policy_config(store_path)?;
     let context = build_context(args);
-    let evidence = load_policy_state(store_path)?
-        .workflows
-        .get(args.workflow_key.as_deref().unwrap_or_default())
-        .cloned();
+    let state = load_policy_state(store_path)?;
+    let (evidence, lifecycle_reason) = args
+        .workflow_key
+        .as_ref()
+        .and_then(|key| state.workflows.get(key))
+        .map(|entry| resolve_evidence(entry, config.defaults.evidence_ttl))
+        .unwrap_or((None, None));
     let decision = evaluate_policy(&config, &context, evidence.as_ref());
+    let mut decision = with_missing_config_reason(&config, decision);
+    if let Some(reason) = lifecycle_reason {
+        decision.reasons.insert(0, reason);
+    }
 
     Ok(policy_result(
         action,
         args.trigger.as_str().to_owned(),
         args.workflow_key.clone(),
-        &with_missing_config_reason(&config, decision),
+        &decision,
     ))
 }
 
 fn record(store_path: &Path, args: &PolicyRecordArgs) -> Result<CommandOutput, CliError> {
     fs::create_dir_all(store_path)?;
     let mut state = load_policy_state(store_path)?;
+    let now_unix = current_unix_timestamp();
     let entry = state
         .workflows
         .entry(args.workflow_key.clone())
@@ -74,12 +150,13 @@ fn record(store_path: &Path, args: &PolicyRecordArgs) -> Result<CommandOutput, C
                         "policy record --action skip_reason requires --reason".to_owned(),
                     )
                 })?;
-            entry.record_skip_reason(reason.clone());
+            entry.evidence.record_skip_reason(reason.clone());
         }
         action => {
-            entry.record_action(action);
+            entry.evidence.record_action(action);
         }
     }
+    entry.touch(now_unix);
 
     save_policy_state(store_path, &state)?;
     Ok(super::status_result(
@@ -90,6 +167,96 @@ fn record(store_path: &Path, args: &PolicyRecordArgs) -> Result<CommandOutput, C
             args.action.as_str(),
             args.workflow_key
         ),
+        Some(store_path.display().to_string()),
+        None,
+    ))
+}
+
+fn clear(store_path: &Path, args: &PolicyClearArgs) -> Result<CommandOutput, CliError> {
+    fs::create_dir_all(store_path)?;
+    let mut state = load_policy_state(store_path)?;
+    let Some(mut entry) = state.workflows.remove(&args.workflow_key) else {
+        return Ok(super::status_result(
+            "policy",
+            "unchanged",
+            format!(
+                "No policy evidence exists for workflow `{}`",
+                args.workflow_key
+            ),
+            Some(store_path.display().to_string()),
+            None,
+        ));
+    };
+
+    let message = if let Some(action) = args.action {
+        clear_action(&mut entry.evidence, action);
+        if entry.is_empty() {
+            format!(
+                "Cleared `{}` and removed now-empty workflow `{}`",
+                action.as_str(),
+                args.workflow_key
+            )
+        } else {
+            entry.touch(current_unix_timestamp());
+            state.workflows.insert(args.workflow_key.clone(), entry);
+            format!(
+                "Cleared `{}` for workflow `{}`",
+                action.as_str(),
+                args.workflow_key
+            )
+        }
+    } else {
+        format!(
+            "Cleared all policy evidence for workflow `{}`",
+            args.workflow_key
+        )
+    };
+
+    save_policy_state(store_path, &state)?;
+    Ok(super::status_result(
+        "policy",
+        "cleared",
+        message,
+        Some(store_path.display().to_string()),
+        None,
+    ))
+}
+
+fn cleanup(store_path: &Path, args: &PolicyCleanupArgs) -> Result<CommandOutput, CliError> {
+    let config = load_policy_config(store_path)?;
+    let ttl = args.ttl.unwrap_or(config.defaults.evidence_ttl);
+    let older_than = cleanup_window(ttl, args.older_than.as_deref())?;
+    let now_unix = current_unix_timestamp();
+
+    let mut state = load_policy_state(store_path)?;
+    let before = state.workflows.len();
+    state.workflows.retain(|_, entry| {
+        if entry.is_empty() {
+            return false;
+        }
+        !is_expired(entry, ttl, older_than, now_unix)
+    });
+    let removed = before.saturating_sub(state.workflows.len());
+
+    if !args.dry_run {
+        fs::create_dir_all(store_path)?;
+        save_policy_state(store_path, &state)?;
+    }
+
+    let lifecycle = if let Some(window) = older_than {
+        format!(
+            "using `{}` TTL and `{}` age threshold",
+            ttl.as_str(),
+            humantime::format_duration(window)
+        )
+    } else {
+        format!("using `{}` TTL with empty-entry cleanup only", ttl.as_str())
+    };
+
+    Ok(super::status_result(
+        "policy",
+        if args.dry_run { "dry_run" } else { "cleaned" },
+        format!("Removed {removed} workflow evidence entries {lifecycle}"),
         Some(store_path.display().to_string()),
         None,
     ))
@@ -160,7 +327,15 @@ fn load_policy_state(store_path: &Path) -> Result<PolicyStateFile, CliError> {
     }
 
     let contents = fs::read_to_string(path)?;
-    serde_json::from_str(&contents).map_err(|error| CliError::PolicyStateParse(error.to_string()))
+    let compat: PolicyStateFileCompat = serde_json::from_str(&contents)
+        .map_err(|error| CliError::PolicyStateParse(error.to_string()))?;
+    Ok(PolicyStateFile {
+        workflows: compat
+            .workflows
+            .into_iter()
+            .map(|(key, value)| (key, value.into()))
+            .collect(),
+    })
 }
 
 fn save_policy_state(store_path: &Path, state: &PolicyStateFile) -> Result<(), CliError> {
@@ -176,4 +351,75 @@ fn policy_config_path(store_path: &Path) -> PathBuf {
 
 fn policy_state_path(store_path: &Path) -> PathBuf {
     store_path.join(POLICY_STATE_FILENAME)
+}
+
+fn clear_action(evidence: &mut PolicyEvidence, action: PolicyAction) {
+    evidence.actions.remove(&action);
+    if matches!(action, PolicyAction::SkipReason) {
+        evidence.skip_reason = None;
+    }
+}
+
+fn resolve_evidence(
+    entry: &PolicyStateEntry,
+    ttl: EvidenceTtl,
+) -> (Option<PolicyEvidence>, Option<String>) {
+    if is_expired(entry, ttl, ttl_max_age(ttl), current_unix_timestamp()) {
+        return (
+            None,
+            Some(format!(
+                "Stored policy evidence expired under `{}` TTL and was ignored for this decision.",
+                ttl.as_str()
+            )),
+        );
+    }
+
+    (Some(entry.evidence.clone()), None)
+}
+
+fn cleanup_window(
+    ttl: EvidenceTtl,
+    older_than: Option<&str>,
+) -> Result<Option<Duration>, CliError> {
+    match older_than {
+        Some(value) => parse_duration(value)
+            .map(Some)
+            .map_err(|error| CliError::PolicyStateParse(error.to_string())),
+        None => Ok(ttl_max_age(ttl)),
+    }
+}
+
+fn ttl_max_age(ttl: EvidenceTtl) -> Option<Duration> {
+    match ttl {
+        EvidenceTtl::Task => Some(TASK_EVIDENCE_MAX_AGE),
+        EvidenceTtl::Session => Some(SESSION_EVIDENCE_MAX_AGE),
+        EvidenceTtl::Manual => None,
+    }
+}
+
+fn is_expired(
+    entry: &PolicyStateEntry,
+    ttl: EvidenceTtl,
+    max_age: Option<Duration>,
+    now_unix: u64,
+) -> bool {
+    if matches!(ttl, EvidenceTtl::Manual) {
+        return false;
+    }
+
+    let Some(max_age) = max_age else {
+        return false;
+    };
+    let Some(last_updated_unix) = entry.last_updated_unix() else {
+        return false;
+    };
+    let age = now_unix.saturating_sub(last_updated_unix);
+    age >= max_age.as_secs()
+}
+
+fn current_unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }

--- a/crates/mnemix-cli/src/cmd/policy.rs
+++ b/crates/mnemix-cli/src/cmd/policy.rs
@@ -114,8 +114,9 @@ fn check(
         .workflow_key
         .as_ref()
         .and_then(|key| state.workflows.get(key))
-        .map(|entry| resolve_evidence(entry, config.defaults.evidence_ttl))
-        .unwrap_or((None, None));
+        .map_or((None, None), |entry| {
+            resolve_evidence(entry, config.defaults.evidence_ttl)
+        });
     let decision = evaluate_policy(&config, &context, evidence.as_ref());
     let mut decision = with_missing_config_reason(&config, decision);
     if let Some(reason) = lifecycle_reason {

--- a/crates/mnemix-cli/tests/cli_flow.rs
+++ b/crates/mnemix-cli/tests/cli_flow.rs
@@ -1259,6 +1259,45 @@ fn policy_recorded_writeback_satisfies_commit_check() {
 }
 
 #[test]
+fn policy_explain_preserves_legacy_state_entries() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let store = temp_dir.path().join("store");
+    let _ = init_store(&store);
+    write_policy_config(&store);
+
+    fs::write(
+        store.join("policy-state.json"),
+        r#"{
+  "workflows": {
+    "commit-1": {
+      "actions": ["writeback"],
+      "skip_reason": null
+    }
+  }
+}"#,
+    )
+    .expect("legacy policy state should be written");
+
+    let explained = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "explain",
+            "--trigger",
+            "on_git_commit",
+            "--workflow-key",
+            "commit-1",
+            "--host",
+            "coding-agent",
+            "--path",
+            "adapters/coding_agent_adapter.py",
+        ],
+    );
+    assert_eq!(explained["data"]["decision"], "allow");
+    assert_eq!(explained["data"]["matched_rules"][0]["satisfied"], true);
+}
+
+#[test]
 fn policy_clear_removes_recorded_action_from_workflow() {
     let temp_dir = tempdir().expect("temp dir should be created");
     let store = temp_dir.path().join("store");
@@ -1311,6 +1350,45 @@ fn policy_clear_removes_recorded_action_from_workflow() {
 }
 
 #[test]
+fn policy_clear_noop_does_not_refresh_unrelated_evidence() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let store = temp_dir.path().join("store");
+    let _ = init_store(&store);
+    write_policy_config(&store);
+
+    let original = r#"{
+  "workflows": {
+    "commit-1": {
+      "evidence": {
+        "actions": ["recall"],
+        "skip_reason": null
+      },
+      "evidence_ttl": "task",
+      "created_at_unix": 10,
+      "updated_at_unix": 20
+    }
+  }
+}"#;
+    fs::write(store.join("policy-state.json"), original).expect("policy state should be written");
+
+    let cleared = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "clear",
+            "--workflow-key",
+            "commit-1",
+            "--action",
+            "writeback",
+        ],
+    );
+    assert_eq!(cleared["data"]["status"], "unchanged");
+
+    let after = fs::read_to_string(store.join("policy-state.json")).expect("policy state");
+    assert_eq!(after, original);
+}
+
+#[test]
 fn policy_explain_ignores_expired_workflow_evidence() {
     let temp_dir = tempdir().expect("temp dir should be created");
     let store = temp_dir.path().join("store");
@@ -1358,6 +1436,129 @@ fn policy_explain_ignores_expired_workflow_evidence() {
             .expect("reason should be string")
             .contains("expired")
     );
+}
+
+#[test]
+fn policy_explain_uses_stored_ttl_instead_of_current_default() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let store = temp_dir.path().join("store");
+    let _ = init_store(&store);
+
+    fs::write(
+        store.join("policy.toml"),
+        r#"
+version = 1
+
+[defaults]
+scope_strategy = "repo"
+evidence_ttl = "task"
+
+[[rules]]
+id = "commit-writeback"
+trigger = "on_git_commit"
+mode = "required"
+requires = ["writeback"]
+allow_skip = false
+on_unsatisfied = "block"
+
+[rules.when]
+host = ["coding-agent"]
+paths_any = ["adapters/**"]
+"#,
+    )
+    .expect("policy config should be written");
+
+    fs::write(
+        store.join("policy-state.json"),
+        r#"{
+  "workflows": {
+    "commit-1": {
+      "evidence": {
+        "actions": ["writeback"],
+        "skip_reason": null
+      },
+      "evidence_ttl": "manual",
+      "created_at_unix": 1,
+      "updated_at_unix": 1
+    }
+  }
+}"#,
+    )
+    .expect("policy state should be written");
+
+    let output = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "explain",
+            "--trigger",
+            "on_git_commit",
+            "--workflow-key",
+            "commit-1",
+            "--host",
+            "coding-agent",
+            "--path",
+            "adapters/coding_agent_adapter.py",
+        ],
+    );
+
+    assert_eq!(output["data"]["decision"], "allow");
+    assert_eq!(output["data"]["matched_rules"][0]["satisfied"], true);
+}
+
+#[test]
+fn policy_cleanup_filters_by_stored_ttl() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let store = temp_dir.path().join("store");
+    let _ = init_store(&store);
+    write_policy_config(&store);
+
+    fs::write(
+        store.join("policy-state.json"),
+        r#"{
+  "workflows": {
+    "manual-workflow": {
+      "evidence": {
+        "actions": ["writeback"],
+        "skip_reason": null
+      },
+      "evidence_ttl": "manual",
+      "created_at_unix": 1,
+      "updated_at_unix": 1
+    }
+  }
+}"#,
+    )
+    .expect("policy state should be written");
+
+    let cleaned = run_json_ok(
+        &store,
+        &["policy", "cleanup", "--ttl", "task", "--older-than", "6h"],
+    );
+    assert_eq!(cleaned["data"]["status"], "cleaned");
+    assert!(
+        cleaned["data"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("stored `task` entries")
+    );
+
+    let explained = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "explain",
+            "--trigger",
+            "on_git_commit",
+            "--workflow-key",
+            "manual-workflow",
+            "--host",
+            "coding-agent",
+            "--path",
+            "adapters/coding_agent_adapter.py",
+        ],
+    );
+    assert_eq!(explained["data"]["decision"], "allow");
 }
 
 #[test]

--- a/crates/mnemix-cli/tests/cli_flow.rs
+++ b/crates/mnemix-cli/tests/cli_flow.rs
@@ -179,6 +179,9 @@ fn start_mock_embeddings_server() -> (String, thread::JoinHandle<()>) {
                 }
                 Err(error) => panic!("incoming stream should be accepted: {error}"),
             };
+            stream
+                .set_nonblocking(false)
+                .expect("accepted stream should switch back to blocking mode");
             let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
             let mut request_line = String::new();
             reader

--- a/crates/mnemix-cli/tests/cli_flow.rs
+++ b/crates/mnemix-cli/tests/cli_flow.rs
@@ -1256,6 +1256,108 @@ fn policy_recorded_writeback_satisfies_commit_check() {
 }
 
 #[test]
+fn policy_clear_removes_recorded_action_from_workflow() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let store = temp_dir.path().join("store");
+    let _ = init_store(&store);
+    write_policy_config(&store);
+
+    let _ = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "record",
+            "--workflow-key",
+            "commit-1",
+            "--action",
+            "writeback",
+        ],
+    );
+
+    let cleared = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "clear",
+            "--workflow-key",
+            "commit-1",
+            "--action",
+            "writeback",
+        ],
+    );
+    assert_eq!(cleared["kind"], "status");
+    assert_eq!(cleared["data"]["status"], "cleared");
+
+    let blocked = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "explain",
+            "--trigger",
+            "on_git_commit",
+            "--workflow-key",
+            "commit-1",
+            "--host",
+            "coding-agent",
+            "--path",
+            "adapters/coding_agent_adapter.py",
+        ],
+    );
+    assert_eq!(blocked["data"]["decision"], "block");
+    assert_eq!(blocked["data"]["missing_actions"][0], "writeback");
+}
+
+#[test]
+fn policy_explain_ignores_expired_workflow_evidence() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let store = temp_dir.path().join("store");
+    let _ = init_store(&store);
+    write_policy_config(&store);
+
+    fs::write(
+        store.join("policy-state.json"),
+        r#"{
+  "workflows": {
+    "commit-1": {
+      "evidence": {
+        "actions": ["writeback"],
+        "skip_reason": null
+      },
+      "created_at_unix": 1,
+      "updated_at_unix": 1
+    }
+  }
+}"#,
+    )
+    .expect("policy state should be written");
+
+    let output = run_json_ok(
+        &store,
+        &[
+            "policy",
+            "explain",
+            "--trigger",
+            "on_git_commit",
+            "--workflow-key",
+            "commit-1",
+            "--host",
+            "coding-agent",
+            "--path",
+            "adapters/coding_agent_adapter.py",
+        ],
+    );
+
+    assert_eq!(output["data"]["decision"], "block");
+    assert_eq!(output["data"]["missing_actions"][0], "writeback");
+    assert!(
+        output["data"]["reasons"][0]
+            .as_str()
+            .expect("reason should be string")
+            .contains("expired")
+    );
+}
+
+#[test]
 fn show_surfaces_missing_memory_as_json_error() {
     let temp_dir = tempdir().expect("temp dir should be created");
     let store = temp_dir.path().join("store");

--- a/crates/mnemix-core/src/policy.rs
+++ b/crates/mnemix-core/src/policy.rs
@@ -187,6 +187,31 @@ pub enum EvidenceTtl {
     Manual,
 }
 
+impl EvidenceTtl {
+    /// Returns the stable string representation used by config and CLI surfaces.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Task => "task",
+            Self::Session => "session",
+            Self::Manual => "manual",
+        }
+    }
+}
+
+impl FromStr for EvidenceTtl {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "task" => Ok(Self::Task),
+            "session" => Ok(Self::Session),
+            "manual" => Ok(Self::Manual),
+            other => Err(format!("unsupported evidence ttl `{other}`")),
+        }
+    }
+}
+
 /// Store-level defaults for policy evaluation.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PolicyDefaults {

--- a/docs_site/src/guide/host-adapters.md
+++ b/docs_site/src/guide/host-adapters.md
@@ -78,6 +78,8 @@ Use coding-agent writeback for:
 The coding adapter also exposes:
 
 - scope helpers with `repo_scope(...)`, `workspace_scope(...)`, `session_scope(...)`, and `task_scope(...)`
+- policy helpers with `check_policy(...)`, `explain_policy(...)`, `record_policy_action(...)`, `clear_policy_workflow(...)`, and `cleanup_policy_state(...)`
+- policy-aware task start and checkpoint evidence recording when a workflow key is supplied
 - targeted search with `search_memory(...)`
 - full memory inspection with `load_memory(...)`
 - typed classification with `classify_outcome(...)`
@@ -96,6 +98,11 @@ The coding adapter also exposes:
 | `session_scope(...)` | Build a standard session scope |
 | `task_scope(...)` | Build a standard task scope |
 | `start_task(...)` | Assemble task-start context with recall, pins, and recent history |
+| `check_policy(...)` | Evaluate coding-agent policy for a trigger |
+| `explain_policy(...)` | Return the explain view for a coding-agent trigger |
+| `record_policy_action(...)` | Record coding-agent policy evidence for a workflow |
+| `clear_policy_workflow(...)` | Clear one workflow's policy evidence |
+| `cleanup_policy_state(...)` | Cleanup empty or expired coding-agent policy evidence |
 | `search_memory(...)` | Run targeted search during implementation work |
 | `load_memory(...)` | Inspect one memory in full detail |
 | `list_pins(...)` | View pinned memory for the current repo or scope |

--- a/docs_site/src/guide/policy-runner.md
+++ b/docs_site/src/guide/policy-runner.md
@@ -39,12 +39,16 @@ CLI commands:
 - `mnemix policy check`
 - `mnemix policy explain`
 - `mnemix policy record`
+- `mnemix policy clear`
+- `mnemix policy cleanup`
 
 Python client methods:
 
 - `Mnemix.policy_check(...)`
 - `Mnemix.policy_explain(...)`
 - `Mnemix.policy_record(...)`
+- `Mnemix.policy_clear(...)`
+- `Mnemix.policy_cleanup(...)`
 
 ## Config files
 
@@ -66,6 +70,12 @@ The policy runner uses local store files:
 - skip reason recorded
 
 This state is host/workflow metadata, not part of the core memory schema.
+
+Each workflow entry now keeps lightweight lifecycle metadata so hosts can:
+
+- clear one workflow when it is done
+- cleanup empty or stale evidence records
+- ignore expired task/session evidence during later checks
 
 ## Rule model
 
@@ -166,13 +176,32 @@ mnemix --store .mnemix policy record \
   --action writeback
 ```
 
+If the workflow is complete and should no longer keep evidence around:
+
+```bash
+mnemix --store .mnemix policy clear \
+  --workflow-key commit-123
+```
+
+For task- or session-scoped cleanup:
+
+```bash
+mnemix --store .mnemix policy cleanup \
+  --ttl task \
+  --older-than 6h
+```
+
 The same surface is available in Python:
 
 ```python
 from pathlib import Path
 
 from mnemix import Mnemix
-from mnemix.models import PolicyCheckRequest, PolicyRecordRequest
+from mnemix.models import (
+    PolicyCheckRequest,
+    PolicyCleanupRequest,
+    PolicyRecordRequest,
+)
 
 client = Mnemix(store=Path(".mnemix"))
 
@@ -192,7 +221,69 @@ if decision.decision == "block":
             action="writeback",
         )
     )
+
+client.policy_cleanup(
+    PolicyCleanupRequest(ttl="task", older_than="6h", dry_run=True)
+)
 ```
+
+## Coding-agent composition
+
+`CodingAgentAdapter` now composes directly with the policy runner instead of
+forcing host code to stitch together raw CLI calls.
+
+Typical flow:
+
+```python
+from pathlib import Path
+
+from adapters import CodingAgentAdapter, CodingOutcome
+
+adapter = CodingAgentAdapter(store=Path(".mnemix"))
+adapter.ensure_store()
+
+task = adapter.start_task(
+    scope=adapter.repo_scope("mnemix"),
+    task_title="Implement policy lifecycle commands",
+    mode="normal",
+    workflow_key="task-001",
+    task_kind="feature",
+    paths=["crates/mnemix-cli/src/cmd/policy.rs"],
+)
+
+result = adapter.store_outcome(
+    CodingOutcome(
+        memory_id="policy-lifecycle-summary",
+        scope=adapter.repo_scope("mnemix"),
+        title="Added policy lifecycle commands",
+        summary="The CLI now supports clearing and cleanup for policy evidence.",
+        detail="`policy clear` removes workflow evidence and `policy cleanup` prunes empty or expired entries.",
+        reusable=True,
+    ),
+    workflow_key="task-001",
+)
+
+print(task.policy_decision)
+print(result.policy_recorded_actions)
+```
+
+The task context surfaces the post-recall policy decision, and durable outcome
+storage can automatically record `classification_selected` and `writeback`
+evidence for the same workflow key.
+
+## Enforcement examples
+
+Reference host-side enforcement examples live under:
+
+```text
+examples/policy-runner/
+```
+
+They cover:
+
+- a coding-agent wrapper flow
+- a local pre-commit style gate
+- a CI/PR verification script
 
 ## Relationship to adapters
 
@@ -225,12 +316,9 @@ For strict workflows, enforcement still belongs in host checkpoints such as:
 
 ## Current limitations
 
-The current implementation is intentionally small:
+The current implementation still keeps scope intentionally tight:
 
 - local file-backed config and evidence only
-- no MCP exposure yet
 - no Python helper around policy config authoring
-- no git-hook integration yet
-- no automatic evidence cleanup or TTL enforcement yet
-
-Those are planned follow-on steps, not part of the current v1 slice.
+- lifecycle cleanup uses conservative built-in task/session age defaults unless a host overrides them
+- MCP exposure is intentionally deferred until host-side workflows prove a real interoperability need

--- a/examples/policy-runner/README.md
+++ b/examples/policy-runner/README.md
@@ -1,0 +1,33 @@
+# Policy Runner Example
+
+This example bundle shows host-side enforcement patterns built on the policy
+runner rather than baking workflow rules into storage.
+
+Included references:
+
+- `coding_agent_wrapper.py`: a Python wrapper that uses `CodingAgentAdapter`
+  policy composition for task start and durable writeback
+- `pre_commit_policy.sh`: a local commit gate that blocks when `policy check`
+  returns `block` or `require_action`
+- `ci_policy_check.sh`: a CI-friendly wrapper that evaluates PR or review
+  policy before continuing
+
+## Why host-side examples
+
+Mnemix can explain and record workflow evidence, but the host remains the place
+that decides whether to stop a commit, fail CI, or continue after guidance.
+
+That keeps:
+
+- storage generic
+- policy inspectable
+- enforcement explicit
+
+## Typical sequence
+
+1. Build a workflow key such as `commit-<sha>` or `pr-<number>`.
+2. Run `mnemix policy check` or `policy explain`.
+3. Record evidence like `recall`, `checkpoint`, or `writeback` when it really
+   happens.
+4. Re-run `policy explain` before the host proceeds.
+5. Clear the workflow or cleanup stale task/session evidence later.

--- a/examples/policy-runner/ci_policy_check.sh
+++ b/examples/policy-runner/ci_policy_check.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+store_path="${MNEMIX_STORE:-.mnemix}"
+workflow_key="${1:-pr-demo}"
+trigger="${2:-on_pr_open}"
+
+result="$(
+  mnemix --store "${store_path}" --json policy explain \
+    --trigger "${trigger}" \
+    --workflow-key "${workflow_key}" \
+    --host ci-bot
+)"
+
+decision="$(
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["decision"])' <<< "${result}"
+)"
+
+echo "${result}"
+
+if [[ "${decision}" == "block" || "${decision}" == "require_action" ]]; then
+  exit 1
+fi

--- a/examples/policy-runner/coding_agent_wrapper.py
+++ b/examples/policy-runner/coding_agent_wrapper.py
@@ -1,0 +1,50 @@
+"""Reference coding-agent wrapper that composes with the policy runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adapters import CodingAgentAdapter, CodingOutcome
+
+
+def main() -> None:
+    adapter = CodingAgentAdapter(store=Path(".mnemix"))
+    adapter.ensure_store()
+
+    workflow_key = "task-policy-runner-demo"
+    scope = adapter.repo_scope("mnemix")
+
+    task = adapter.start_task(
+        scope=scope,
+        task_title="Implement policy lifecycle commands",
+        mode="normal",
+        workflow_key=workflow_key,
+        task_kind="feature",
+        paths=["crates/mnemix-cli/src/cmd/policy.rs"],
+    )
+
+    print(task.prompt_preamble)
+    if task.policy_decision is not None:
+        print(f"policy decision after recall: {task.policy_decision.decision}")
+
+    result = adapter.store_outcome(
+        CodingOutcome(
+            memory_id="policy-runner-lifecycle-demo",
+            scope=scope,
+            title="Added policy lifecycle support",
+            summary="The workflow can now clear and cleanup policy evidence.",
+            detail=(
+                "Hosts can clear one workflow or cleanup expired task/session "
+                "evidence without pushing policy state into storage."
+            ),
+            reusable=True,
+            tags=["policy"],
+        ),
+        workflow_key=workflow_key,
+    )
+    print(f"stored: {result.stored}")
+    print(f"recorded policy actions: {result.policy_recorded_actions}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/policy-runner/pre_commit_policy.sh
+++ b/examples/policy-runner/pre_commit_policy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+store_path="${MNEMIX_STORE:-.mnemix}"
+workflow_key="commit-$(git rev-parse --short HEAD)"
+changed_files="$(git diff --cached --name-only)"
+
+if [[ -z "${changed_files}" ]]; then
+  exit 0
+fi
+
+args=()
+while IFS= read -r path; do
+  args+=(--path "$path")
+done <<< "${changed_files}"
+
+result="$(
+  mnemix --store "${store_path}" --json policy check \
+    --trigger on_git_commit \
+    --workflow-key "${workflow_key}" \
+    --host coding-agent \
+    "${args[@]}"
+)"
+
+decision="$(
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["decision"])' <<< "${result}"
+)"
+
+if [[ "${decision}" == "block" || "${decision}" == "require_action" ]]; then
+  echo "policy runner blocked commit workflow ${workflow_key}" >&2
+  echo "${result}" >&2
+  exit 1
+fi

--- a/python/mnemix/__init__.py
+++ b/python/mnemix/__init__.py
@@ -42,8 +42,11 @@ from .models import (
     OptimizeRetentionResult,
     PolicyAction,
     PolicyCheckRequest,
+    PolicyCleanupRequest,
+    PolicyClearRequest,
     PolicyDecisionKind,
     PolicyDecisionResult,
+    EvidenceTtl,
     PolicyMode,
     PolicyRecordRequest,
     PolicyRuleEvaluation,
@@ -76,6 +79,8 @@ __all__ = [
     "RestoreRequest",
     "OptimizeRequest",
     "PolicyCheckRequest",
+    "PolicyClearRequest",
+    "PolicyCleanupRequest",
     "PolicyRecordRequest",
     # response models
     "MemorySummary",
@@ -99,6 +104,7 @@ __all__ = [
     "PolicyMode",
     "PolicyDecisionKind",
     "ScopeStrategy",
+    "EvidenceTtl",
     # version
     "__version__",
 ]

--- a/python/mnemix/client.py
+++ b/python/mnemix/client.py
@@ -41,6 +41,8 @@ from .models import (
     OptimizeRequest,
     OptimizeResult,
     PolicyCheckRequest,
+    PolicyCleanupRequest,
+    PolicyClearRequest,
     PolicyDecisionResult,
     PolicyRecordRequest,
     RecallRequest,
@@ -344,6 +346,28 @@ class Mnemix:
         ]
         if request.reason is not None:
             args += ["--reason", request.reason]
+        data = self._run("policy", args)
+        return StatusResult.from_dict(data)
+
+    def policy_clear(self, request: PolicyClearRequest) -> StatusResult:
+        """Clear policy evidence for one workflow key."""
+        args = ["clear", "--workflow-key", request.workflow_key]
+        if request.action is not None:
+            args += ["--action", request.action]
+        data = self._run("policy", args)
+        return StatusResult.from_dict(data)
+
+    def policy_cleanup(self, request: PolicyCleanupRequest | None = None) -> StatusResult:
+        """Cleanup empty or expired policy evidence entries."""
+        if request is None:
+            request = PolicyCleanupRequest()
+        args = ["cleanup"]
+        if request.ttl is not None:
+            args += ["--ttl", request.ttl]
+        if request.older_than is not None:
+            args += ["--older-than", request.older_than]
+        if request.dry_run:
+            args.append("--dry-run")
         data = self._run("policy", args)
         return StatusResult.from_dict(data)
 

--- a/python/mnemix/models.py
+++ b/python/mnemix/models.py
@@ -59,6 +59,7 @@ PolicyAction = Literal[
 PolicyMode = Literal["guided", "required", "required_with_skip_reason"]
 PolicyDecisionKind = Literal["allow", "allow_with_recommendation", "require_action", "block"]
 ScopeStrategy = Literal["repo", "workspace", "session", "task"]
+EvidenceTtl = Literal["task", "session", "manual"]
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +166,23 @@ class PolicyRecordRequest:
     def __post_init__(self) -> None:
         if self.action == "skip_reason" and (self.reason is None or not self.reason.strip()):
             raise ValueError("Provide 'reason' when recording action 'skip_reason'.")
+
+
+@dataclass(frozen=True)
+class PolicyClearRequest:
+    """Parameters for the ``policy clear`` command."""
+
+    workflow_key: str
+    action: PolicyAction | None = None
+
+
+@dataclass(frozen=True)
+class PolicyCleanupRequest:
+    """Parameters for the ``policy cleanup`` command."""
+
+    ttl: EvidenceTtl | None = None
+    older_than: str | None = None
+    dry_run: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -18,6 +18,8 @@ from mnemix.models import (
     CheckpointRequest,
     OptimizeRequest,
     PolicyCheckRequest,
+    PolicyCleanupRequest,
+    PolicyClearRequest,
     PolicyRecordRequest,
     RecallRequest,
     RememberRequest,
@@ -475,6 +477,49 @@ class TestPolicy:
         assert result.status == "recorded"
         args = mock_run.call_args[0][2]
         assert args == ["record", "--workflow-key", "wf-1", "--action", "writeback"]
+
+    def test_policy_clear_returns_status(self, tp: Mnemix) -> None:
+        with patch("mnemix._runner.run") as mock_run:
+            mock_run.return_value = {
+                "command": "policy",
+                "status": "cleared",
+                "message": "Cleared `writeback` for workflow `wf-1`",
+                "path": "/tmp/test-store",
+                "schema_version": None,
+            }
+            result = tp.policy_clear(
+                PolicyClearRequest(workflow_key="wf-1", action="writeback")
+            )
+        assert result.status == "cleared"
+        assert mock_run.call_args[0][2] == [
+            "clear",
+            "--workflow-key",
+            "wf-1",
+            "--action",
+            "writeback",
+        ]
+
+    def test_policy_cleanup_accepts_optional_args(self, tp: Mnemix) -> None:
+        with patch("mnemix._runner.run") as mock_run:
+            mock_run.return_value = {
+                "command": "policy",
+                "status": "dry_run",
+                "message": "Removed 1 workflow evidence entries using `task` TTL",
+                "path": "/tmp/test-store",
+                "schema_version": None,
+            }
+            result = tp.policy_cleanup(
+                PolicyCleanupRequest(ttl="task", older_than="2h", dry_run=True)
+            )
+        assert result.status == "dry_run"
+        assert mock_run.call_args[0][2] == [
+            "cleanup",
+            "--ttl",
+            "task",
+            "--older-than",
+            "2h",
+            "--dry-run",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -12,6 +12,8 @@ from mnemix.models import (
     OptimizeRequest,
     OptimizeResult,
     PolicyCheckRequest,
+    PolicyCleanupRequest,
+    PolicyClearRequest,
     PolicyDecisionResult,
     PolicyRecordRequest,
     RecallEntry,
@@ -154,6 +156,21 @@ class TestPolicyRecordRequest:
     def test_skip_reason_requires_reason(self) -> None:
         with pytest.raises(ValueError, match="Provide 'reason'"):
             PolicyRecordRequest(workflow_key="wf-1", action="skip_reason")
+
+
+class TestPolicyClearRequest:
+    def test_defaults(self) -> None:
+        req = PolicyClearRequest(workflow_key="wf-1")
+        assert req.workflow_key == "wf-1"
+        assert req.action is None
+
+
+class TestPolicyCleanupRequest:
+    def test_defaults(self) -> None:
+        req = PolicyCleanupRequest()
+        assert req.ttl is None
+        assert req.older_than is None
+        assert req.dry_run is False
 
 
 # ---------------------------------------------------------------------------

--- a/workflow/patches/0019-add-policy-runner-enforcement-adapters-and-examples.md
+++ b/workflow/patches/0019-add-policy-runner-enforcement-adapters-and-examples.md
@@ -1,7 +1,7 @@
 ---
-status: open
-summary: "Implement the first enforcement-oriented policy-runner integrations."
-updated: "2026-03-21"
+status: completed
+summary: "Shipped reference policy-runner enforcement examples for wrappers, local hooks, and CI/PR flows."
+updated: "2026-04-05"
 ---
 
 # Patch: Add policy runner enforcement adapters and examples
@@ -16,22 +16,25 @@ This patch preserves legacy Dex history after the repository moved to repo-nativ
 
 ## Scope
 
-- Preserve the original Dex task details for `wjqmxdqh`.
-- Keep the tracked status aligned with the final Dex state: `open`.
-- Avoid reinterpreting the historical task beyond the recorded Dex description and outcome.
+- Add a reference coding-agent wrapper flow
+- Add a local pre-commit style enforcement example
+- Add a CI/PR policy verification example
+- Keep enforcement host-side instead of moving it into storage or MCP
 
 ## Implementation Notes
 
-- Imported from legacy Dex tracking during the 2026-03-30 workflow migration.
-- Original Dex task ID: `wjqmxdqh`
-- Created: 2026-03-21
-- Started: Not recorded
-- Completed: Not recorded
+- Added `examples/policy-runner/README.md`
+- Added `examples/policy-runner/coding_agent_wrapper.py`
+- Added `examples/policy-runner/pre_commit_policy.sh`
+- Added `examples/policy-runner/ci_policy_check.sh`
+- Updated the policy-runner and host-adapter guides to point at the new
+  enforcement examples
 
 ## Validation
 
-- This task was still open in Dex when the history was imported.
-- Migration check: imported into `workflow/patches/` for repo-native tracking.
+- Verified policy-related Python and adapter tests through the repo virtualenv
+- Kept the example flows host-side and based on `policy check`, `policy
+  explain`, and `policy record`
 
 ## References
 

--- a/workflow/patches/0020-evaluate-and-expose-policy-runner-via-mcp.md
+++ b/workflow/patches/0020-evaluate-and-expose-policy-runner-via-mcp.md
@@ -1,7 +1,7 @@
 ---
-status: open
-summary: "Evaluate whether MCP adds value as an interoperability layer for the policy runner, then implement the initial MCP surf\u2026"
-updated: "2026-03-21"
+status: completed
+summary: "Deferred MCP exposure for the policy runner until host-side workflows demonstrate a concrete interoperability need."
+updated: "2026-04-05"
 ---
 
 # Patch: Evaluate and expose policy runner via MCP
@@ -16,22 +16,25 @@ This patch preserves legacy Dex history after the repository moved to repo-nativ
 
 ## Scope
 
-- Preserve the original Dex task details for `3108zh39`.
-- Keep the tracked status aligned with the final Dex state: `open`.
-- Avoid reinterpreting the historical task beyond the recorded Dex description and outcome.
+- Evaluate whether MCP adds enough value beyond the host-side policy surfaces
+- Document the decision in repo-native workflow and user-facing guides
+- Preserve the design rule that enforcement remains host-side
 
 ## Implementation Notes
 
-- Imported from legacy Dex tracking during the 2026-03-30 workflow migration.
-- Original Dex task ID: `3108zh39`
-- Created: 2026-03-21
-- Started: Not recorded
-- Completed: Not recorded
+- Reviewed the current policy surface after lifecycle commands, enforcement
+  examples, and `CodingAgentAdapter` composition landed
+- Deferred MCP because wrapper scripts, hooks, CI, and adapter composition now
+  cover the primary host-side enforcement paths without adding another contract
+  to maintain
+- Updated `workflow/workstreams/001-.../STATUS.md`, `tasks.md`, `plan.md`, and
+  `docs_site/src/guide/policy-runner.md` to reflect the defer decision
 
 ## Validation
 
-- This task was still open in Dex when the history was imported.
-- Migration check: imported into `workflow/patches/` for repo-native tracking.
+- The policy-runner guide now documents MCP as intentionally deferred
+- The workstream tracking artifacts mark issue `#81` as resolved by an explicit
+  defer decision
 
 ## References
 

--- a/workflow/workstreams/001-policy-runner-guided-and-required-memory-workflows/STATUS.md
+++ b/workflow/workstreams/001-policy-runner-guided-and-required-memory-workflows/STATUS.md
@@ -1,7 +1,7 @@
 ---
-status: open
-summary: Policy runner planning is complete and the remaining implementation backlog is tracked under issues #81, #82, #83, and #84.
-updated: 2026-03-31
+status: completed
+summary: Policy runner lifecycle commands, enforcement examples, and CodingAgentAdapter composition are now shipped, and MCP is explicitly deferred until a concrete interoperability need appears.
+updated: 2026-04-05
 prs:
   - 66
   - 79
@@ -20,12 +20,17 @@ implementation slices already landed:
   closed after PR `#66`
 - `#76` shipped the initial policy runner surface and was closed after PR `#79`
 
-The remaining active backlog for this workstream is:
+The final follow-on slices are now represented in the repo:
 
-- `#81` evaluate and expose policy runner via MCP
-- `#82` add policy runner enforcement adapters and examples
-- `#83` add policy runner state lifecycle commands
-- `#84` compose policy runner with `CodingAgentAdapter`
+- `#82` shipped reference enforcement examples for local hooks, wrappers, and
+  CI/PR policy checks
+- `#83` shipped `policy clear` and `policy cleanup`, lifecycle metadata in
+  `policy-state.json`, and TTL-aware task/session evidence handling
+- `#84` composed the policy runner with `CodingAgentAdapter` task start,
+  checkpoint, and writeback flows
+- `#81` is explicitly deferred for now because host-side enforcement paths are
+  sufficient and MCP does not yet add enough interoperability value to justify
+  another surface area
 
 ## References
 

--- a/workflow/workstreams/001-policy-runner-guided-and-required-memory-workflows/plan.md
+++ b/workflow/workstreams/001-policy-runner-guided-and-required-memory-workflows/plan.md
@@ -28,8 +28,8 @@ it.
 - [x] CLI implementation
 - [x] Python wrapper
 - [x] Adapter surface
-- [ ] Hooks and reference enforcement examples
-- [ ] MCP interoperability layer
+- [x] Hooks and reference enforcement examples
+- [x] MCP interoperability layer evaluation is documented as deferred
 
 ## Technical Design
 
@@ -72,23 +72,24 @@ docs/ or workflow/workstreams/001-.../            # canonical explanation of the
 
 ### Slice 2: State Lifecycle
 
-- Issue `#83`: add evidence cleanup, clear behavior, TTL handling, and related
-  CLI/Python surfaces
+- Completed: issue `#83` added evidence cleanup, clear behavior, TTL handling,
+  and related CLI/Python surfaces
 
 ### Slice 3: Enforcement Examples
 
-- Issue `#82`: add reference git-hook, wrapper CLI, and CI/PR enforcement
-  examples
+- Completed: issue `#82` added reference git-hook, wrapper CLI, and CI/PR
+  enforcement examples
 
 ### Slice 4: Adapter Composition
 
-- Issue `#84`: compose policy checks with `CodingAgentAdapter` start, writeback,
-  and checkpoint flows
+- Completed: issue `#84` composes policy checks with `CodingAgentAdapter`
+  start, writeback, and checkpoint flows
 
 ### Slice 5: MCP Evaluation
 
-- Issue `#81`: evaluate whether MCP adds value as an interoperability surface
-  and either implement or explicitly defer it
+- Completed as a defer decision: issue `#81` was evaluated and explicitly
+  deferred until host-side enforcement patterns demonstrate a concrete need for
+  an additional transport surface
 
 ## Risks
 

--- a/workflow/workstreams/001-policy-runner-guided-and-required-memory-workflows/tasks.md
+++ b/workflow/workstreams/001-policy-runner-guided-and-required-memory-workflows/tasks.md
@@ -18,31 +18,31 @@ follow-on issues are tracked as active execution slices.
 
 ### State Lifecycle
 
-- [ ] Implement issue `#83`: clear and cleanup flows for policy evidence,
+- [x] Implement issue `#83`: clear and cleanup flows for policy evidence,
   lifecycle handling, and TTL-aware behavior
 
 ### Enforcement Integrations
 
-- [ ] Implement issue `#82`: reference enforcement adapters and examples for
+- [x] Implement issue `#82`: reference enforcement adapters and examples for
   hooks, CI, and wrapper flows
 
 ### Coding-Agent Composition
 
-- [ ] Implement issue `#84`: higher-level composition between the policy runner
+- [x] Implement issue `#84`: higher-level composition between the policy runner
   and `CodingAgentAdapter`
 
 ### MCP Interoperability
 
-- [ ] Implement or explicitly defer issue `#81`: MCP-facing policy surface and
+- [x] Implement or explicitly defer issue `#81`: MCP-facing policy surface and
   rationale
 
 ## Validation Checklist
 
-- [ ] Keep `STATUS.md` aligned with shipped slices and remaining issue backlog
-- [ ] Keep follow-on GitHub issue status in sync as slices land
-- [ ] Verify new policy surfaces through targeted Rust, Python, and adapter
+- [x] Keep `STATUS.md` aligned with shipped slices and remaining issue backlog
+- [x] Keep follow-on GitHub issue status in sync as slices land
+- [x] Verify new policy surfaces through targeted Rust, Python, and adapter
   tests
-- [ ] Preserve the host-side enforcement model when adding examples or MCP
+- [x] Preserve the host-side enforcement model when adding examples or MCP
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add `policy clear` and `policy cleanup` with backward-compatible policy-state lifecycle handling and TTL-aware task/session evidence behavior
- compose `CodingAgentAdapter` with policy check/explain/record/clear/cleanup flows and automatic workflow evidence recording
- add reference enforcement examples for coding-agent wrappers, local hook-style checks, and CI/PR policy gates
- update docs and workstream tracking to mark `#82`, `#83`, and `#84` shipped and `#81` explicitly deferred

## Validation
- `cargo test -p mnemix-cli policy_ --manifest-path mnemix/Cargo.toml`
- `mnemix/python/.venv/bin/python -m pytest mnemix/python/tests/test_client.py -k policy mnemix/python/tests/test_models.py -k Policy mnemix/adapters/tests/test_host_adapters.py -k policy`

Closes #81
Closes #82
Closes #83
Closes #84