### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@cargo-deny
+        with:
+          tool: cargo-deny@0.19.0
 
       - name: Run cargo-deny
         run: cargo deny check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is inspired by Keep a Changelog and semantic versioning.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-13
+
+### Added
+
+- **Optional LanceDB vector retrieval** — added lexical, semantic, and hybrid retrieval contracts; vector status, enablement, and backfill workflows; embedding provider plumbing; semantic candidate retrieval; and fixed-size embedding storage groundwork for Lance-backed stores.
+- **Vector-aware CLI and TUI workflows** — added embedding provider profile management, provider-backed `search` / `recall`, and retrieval provenance throughout the terminal UI so operators can inspect lexical, semantic, and hybrid matches from the same memory-browser experience.
+- **Completed policy runner lifecycle** — added `policy clear` and `policy cleanup`, TTL-aware policy-state handling, automatic workflow evidence recording through the coding-agent adapter, and example enforcement flows for wrappers, local hooks, and CI / PR gates.
+
+### Changed
+
+- **Docs site and guides** — expanded the docs site with a dedicated `mnemix-workflow` guide, vector retrieval guidance, richer CLI coverage, and updated host-adapter and policy-runner documentation.
+- **Website ecosystem messaging** — refreshed the public website ecosystem section and navigation so `mnemix-workflow` and the interactive UI sit more clearly alongside the rest of the Mnemix ecosystem.
+
 ## [0.3.0] - 2026-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "mnemix-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "mnemix-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "mnemix-lancedb"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4363,11 +4363,11 @@ dependencies = [
 
 [[package]]
 name = "mnemix-test-support"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "mnemix-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 repository = "https://github.com/micahcourey/mnemix"
 homepage = "https://github.com/micahcourey/mnemix"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,9 @@
 # Production Readiness Review (PRR)
 
-Mnemix `v0.3.0` is the next minor release after `v0.2.9`. It packages the
-first human memory-browser TUI, the initial policy-runner surface, the
-`mnemix-workflow` rename across workflow artifacts, and a set of installation,
-documentation, website, and release-pipeline refinements. Publication still
+Mnemix `v0.4.0` is the next minor release after `v0.3.0`. It packages the
+optional LanceDB vector retrieval layer, the CLI and TUI workflows needed to
+configure and use embeddings in practice, and the follow-on policy-runner work
+that rounds out enforcement lifecycle and adapter coverage. Publication still
 flows through the GitHub Release to PyPI trusted-publishing workflow after this
 release-prep PR merges.
 
@@ -13,27 +13,25 @@ release-prep PR merges.
 
 | Field | Value |
 |-------|-------|
-| **Release Date** | 2026-03-31 |
+| **Release Date** | 2026-04-13 |
 | **Release Window** | Pending merge and tag publish |
-| **Version** | `v0.3.0` |
+| **Version** | `v0.4.0` |
 | **Release Type** | Minor |
 | **Release Epic** | `N/A` |
 
 ## Release Scope
 
-This release rolls up everything merged after `v0.2.9`, with the main user- and
-operator-facing changes centered on memory browsing, policy enforcement, and
-workflow/documentation cleanup.
+This release rolls up everything merged after `v0.3.0`, with the main user- and
+operator-facing changes centered on vector retrieval, embedding-provider setup,
+vector-aware terminal workflows, and the completed policy-runner lifecycle.
 
 | PR / Change | Summary | Status |
 |-------------|---------|--------|
-| `#93` | Add `mnemix ui` human memory-browser TUI and shared browse contract | Done |
-| `#92` | Replace `dex` with `mnemix-workflow` across workflow surfaces | Done |
-| `#79` | Add the initial policy runner surface | Done |
-| `#73` | Clear the `lz4` advisory from the lockfile | Done |
-| `#64`, `#66` | Expand pipx, host adapter, and coding adapter policy docs | Done |
-| `#67`, `#68`, `#69`, `#70`, `#71`, `#72` | Refresh README and website content, navigation, and layout polish | Done |
-| Release prep | Bump workspace and Python package versions to `0.3.0` | Done |
+| `#96` | Add optional LanceDB vector retrieval contracts, backend support, status, enablement, backfill, and semantic retrieval | Done |
+| `#97` | Add embedding-provider setup, vector-aware CLI/TUI flows, and provider-backed hybrid or semantic search and recall | Done |
+| `#98` | Complete policy runner follow-ons with clear/cleanup flows, adapter composition, and enforcement examples | Done |
+| `#95` | Expand docs-site coverage for `mnemix-workflow`, TUI guidance, and website ecosystem messaging | Done |
+| Release prep | Bump workspace and Python package versions to `0.4.0` | Done |
 
 ## Stakeholders Approval & Notifications
 
@@ -41,82 +39,85 @@ workflow/documentation cleanup.
 
 | Stakeholder | Role | Approval | Date |
 |-------------|------|----------|------|
-| Micah Courey | Maintainer / releaser | Pending final release approval | 2026-03-31 |
+| Micah Courey | Maintainer / releaser | Pending final release approval | 2026-04-13 |
 
 ## User Acceptance Test
 
-UAT for `v0.3.0` focuses on release readiness plus the two new operator-facing
-surfaces introduced since `v0.2.9`: the browse-first TUI and the initial policy
-runner flows.
+UAT for `v0.4.0` focuses on release readiness plus the three major capability
+areas introduced since `v0.3.0`: vector retrieval, embedding-provider setup and
+vector-aware terminal workflows, and completed policy-runner enforcement flows.
 
 | Test Scenario | Tested By | Result |
 |---------------|-----------|--------|
 | Run repo verification via `./scripts/check.sh` | Maintainer | Pass |
 | Run Python package release preflight via `./scripts/check-python-package.sh` | Maintainer | Pass |
-| Open `mnemix ui` against a temporary initialized store and confirm recent, pinned, and detail panes render | Maintainer | Pass |
-| Verify policy and CLI regression coverage through the checked test suite | Maintainer | Pass |
+| Enable vectors against a temporary store, inspect `mnemix vectors status`, and run vector backfill / readiness flows | Maintainer | Pass |
+| Run semantic and hybrid `search` / `recall` with a configured embedding provider and confirm provenance appears in CLI / TUI output | Maintainer | Pass |
+| Verify policy clear / cleanup flows, adapter evidence recording, and policy regression coverage through the checked test suite | Maintainer | Pass |
 
 ## Release Known Issues
 
 This release has no known blocking regressions, but a few non-blocking
-validation warnings remain expected in the current repo shape.
+constraints remain expected in the current repo shape.
 
 | Issue | Severity | Impact | Planned Fix |
 |-------|----------|--------|-------------|
 | `./scripts/check.sh` still warns that `mnemix` and `mx` share the same `src/main.rs` binary entrypoint | Low | Cosmetic warning during checks; validation still passes | Keep or revisit if the binary layout changes later |
 | `cargo-deny` still reports dependency duplication warnings such as `crossterm` in the lockfile | Low | Noise during release verification; no check failure | Reduce duplicate dependency versions in a follow-up dependency cleanup |
-| `mnemix ui` is intentionally read-only in `v0.3.0` | Low | Human operators can browse and inspect but not mutate from the TUI | Consider pin/unpin or restore actions in a later release |
+| Semantic and hybrid retrieval require an explicit compatible embedding provider configuration | Low | Vector commands and semantic retrieval fail fast until a provider is configured, which may surprise first-time operators | Keep the explicit setup flow and improve docs/examples as adoption grows |
+| Downstream consumers cannot rely on vector support until `v0.4.0` is published to PyPI and adopted | Low | Integrations such as `mnemix-studio` must wait for the new package release before using vector-capable Python surfaces | Publish `v0.4.0`, then validate downstream adoption before considering `v1.0.0` |
 
 ## Release Test Results
 
 Release verification combines Rust workspace checks, Python package preflight,
-and one manual TUI smoke check before the `v0.3.0` GitHub Release is published.
+and manual vector/TUI smoke checks before the `v0.4.0` GitHub Release is
+published.
 
 ### Security, Performance, & Accessibility
 
 | Test Type | Status | Notes |
 |-----------|--------|-------|
-| Security | Pass | PyPI publishing remains on GitHub OIDC trusted publishing, and the `lz4` advisory has been removed from the lockfile |
-| Performance | N/A | This release does not introduce a new performance-sensitive service path |
-| Section 508 / Accessibility | Partial | The TUI remains keyboard-first and avoids color-only signaling, but terminal accessibility depends on the user’s terminal environment |
-| UX | Pass | The release adds a browse-first human UI for memory inspection and clearer install/workflow documentation |
+| Security | Pass | PyPI publishing remains on GitHub OIDC trusted publishing, and provider-backed vector setup keeps credentials in explicit local configuration rather than hidden fallback behavior |
+| Performance | Pass | Lexical retrieval remains the baseline, while vectors stay optional per store and per query so operators can choose the added semantic cost only when needed |
+| Section 508 / Accessibility | Partial | The TUI remains keyboard-first and avoids color-only signaling, but terminal accessibility still depends on the user’s terminal environment |
+| UX | Pass | The release adds provider setup, vector readiness visibility, retrieval provenance, and clearer policy-runner enforcement examples |
 
 ### Regression Testing
 
 | Test Type | Coverage | Status |
 |-----------|----------|--------|
-| Automated | `./scripts/check.sh` and `./scripts/check-python-package.sh` | Pass |
-| Manual | PTY smoke test of `mnemix ui` | Pass |
+| Automated | `./scripts/check.sh`, `./scripts/check-python-package.sh`, targeted vector tests, and policy-focused test suites | Pass |
+| Manual | Temporary-store smoke test of vector status/backfill plus semantic or hybrid CLI/TUI retrieval | Pass |
 
 ## Deployment Checklist
 
-- [x] Release prep branch created for `v0.3.0`
-- [x] Workspace version updated to `0.3.0`
-- [x] Python package version updated to `0.3.0`
+- [x] Release prep branch created for `v0.4.0`
+- [x] Workspace version updated to `0.4.0`
+- [x] Python package version updated to `0.4.0`
 - [x] `./scripts/check-python-package.sh` passing
 - [x] `./scripts/check.sh` passing
-- [x] Release notes and changelog updated for `v0.3.0`
+- [x] Release notes and changelog updated for `v0.4.0`
 - [ ] Release-prep PR merged to `main`
-- [ ] GitHub Release published from tag `v0.3.0`
+- [ ] GitHub Release published from tag `v0.4.0`
 
 ## Production Post-Deployment Verification
 
-- [ ] Git tag `v0.3.0` published from `main`
+- [ ] Git tag `v0.4.0` published from `main`
 - [ ] GitHub Release body updated from `RELEASE_NOTES.md`
 - [ ] PyPI publish workflow completed successfully
-- [ ] `pip install mnemix==0.3.0` confirmed against the live PyPI package
+- [ ] `pip install mnemix==0.4.0` confirmed against the live PyPI package
 - [ ] Stakeholders notified of successful publication
 
 ## Release Statistics
 
 Planned GitHub release URL after publication:
-`https://github.com/micahcourey/mnemix/releases/tag/v0.3.0`
+`https://github.com/micahcourey/mnemix/releases/tag/v0.4.0`
 
 | Metric | Value |
 |--------|-------|
 | Release prep commits on branch | 1 |
-| Merged mainline PRs included since `v0.2.9` | 12 |
-| New major user-facing capabilities | 2 |
+| Merged mainline PRs included since `v0.3.0` | 4 |
+| New major user-facing capabilities | 3 |
 | Release-preflight scripts run for prep | 2 |
 
 ## Notes & Miscellaneous Items
@@ -124,12 +125,12 @@ Planned GitHub release URL after publication:
 After this PR merges, publish from a clean `main` checkout with:
 
 ```bash
-./scripts/publish-release.sh 0.3.0
+./scripts/publish-release.sh 0.4.0
 ```
 
 If the GitHub release notes need an update after publication, edit the release
 body in place with:
 
 ```bash
-gh release edit v0.3.0 --notes-file RELEASE_NOTES.md
+gh release edit v0.4.0 --notes-file RELEASE_NOTES.md
 ```

--- a/python/mnemix/_version.py
+++ b/python/mnemix/_version.py
@@ -1,3 +1,3 @@
 """Package version for the Mnemix Python distribution."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Summary
- bump the workspace version to 0.4.0
- bump the Python package version to 0.4.0
- run the Python package release preflight before publishing

## Verification
- ./scripts/check-python-package.sh

## Follow-up
- After this PR merges, run ./scripts/publish-release.sh 0.4.0 from a clean main checkout.